### PR TITLE
Add gradient accumulation, fix lr scheduler

### DIFF
--- a/colossalai/builder/builder.py
+++ b/colossalai/builder/builder.py
@@ -235,7 +235,7 @@ def build_optimizer_wrapper(config, optimizer, model=None):
         return OPTIMIZER_WRAPPERS.get_module(mod_type)(optimizer, **config_)
 
 
-def build_lr_scheduler(config, optimizer, total_steps, num_steps_per_epoch):
+def build_lr_scheduler(config, optimizer):
     """Returns a learning rate scheduler object of :class:`torch.optim.lr_scheduler` 
     constructed from `config`, `optimizer`, `total_steps` and `num_steps_per_epoch`.
 
@@ -255,8 +255,7 @@ def build_lr_scheduler(config, optimizer, total_steps, num_steps_per_epoch):
     config_ = config.copy()
     mod_type = config_.pop('type')
     # warmup epochs will overwrite warmup steps
-    if 'warmup_epochs' in config_:
-        warmup_epochs = config_.pop('warmup_epochs')
-        config_['warmup_steps'] = int(num_steps_per_epoch * warmup_epochs)
-    return LR_SCHEDULERS.get_module(mod_type)(optimizer, total_steps, num_steps_per_epoch=num_steps_per_epoch,
-                                              **config_)
+    # if 'warmup_epochs' in config_:
+    #     warmup_epochs = config_.pop('warmup_epochs')
+    #     config_['warmup_steps'] = int(num_steps_per_epoch * warmup_epochs)
+    return LR_SCHEDULERS.get_module(mod_type)(optimizer, **config_)

--- a/colossalai/engine/schedule/_pipeline.py
+++ b/colossalai/engine/schedule/_pipeline.py
@@ -119,19 +119,20 @@ class PipelineSchedule(BaseSchedule):
 
     @property
     def num_steps(self):
-        return len(self.dataloader)
+        length = len(self.dataloader)
+        if self.training:
+            length -= length % self.grad_accum
+        return length
 
     def initialize(self,
-                   dataloader,
-                   model,
-                   criterion,
-                   optimizer,
-                   lr_scheduler=None):
+                   dataloader=None,
+                   model=None,
+                   criterion=None,
+                   optimizer=None):
         super().initialize(dataloader,
                            model,
                            criterion,
-                           optimizer,
-                           lr_scheduler=lr_scheduler)
+                           optimizer)
         if isinstance(self.optimizer, (ZeroRedundancyOptimizer_Level_2,
                                        ZeroRedundancyOptimizer_Level_3)):
             raise TypeError(
@@ -163,7 +164,7 @@ class PipelineSchedule(BaseSchedule):
             if return_loss:
                 input_tensor, label = self.load_micro_batch()
                 loss_reduced = self.criterion(output_tensor, *
-                label) / self.num_microbatches
+                label) / (self.num_microbatches * self.grad_accum)
                 return_tensors.append(
                     tuple((output_tensor, label[0], loss_reduced)))
                 return loss_reduced
@@ -309,7 +310,7 @@ class PipelineSchedule(BaseSchedule):
                 output, label, loss = tuple(map(list, zip(*return_tensors)))
                 return (torch.cat(output, dim=0),
                         torch.cat(label, dim=0),
-                        sum(loss))
+                        sum(loss) * self.grad_accum)
             else:
                 return tuple((torch.cat(return_tensors, dim=0), None, None))
         else:

--- a/colossalai/initialize.py
+++ b/colossalai/initialize.py
@@ -339,16 +339,15 @@ def initialize(config: Union[str, dict] = None,
 
     lr_scheduler = None
     if hasattr(gpc.config, 'lr_scheduler'):
-        if hasattr(gpc.config, 'num_steps'):
-            total_steps = gpc.config.num_steps
-        elif hasattr(gpc.config, 'num_epochs'):
-            total_steps = int(gpc.config.num_epochs * len(train_dataloader))
-        else:
-            raise Exception(
-                'Please specify training stopping criterion num_steps or num_epochs in your configuration.'
-            )
-        lr_scheduler = build_lr_scheduler(gpc.config.lr_scheduler, optimizer,
-                                          total_steps, len(train_dataloader))
+        # if hasattr(gpc.config, 'num_steps'):
+        #     total_steps = gpc.config.num_steps
+        # elif hasattr(gpc.config, 'num_epochs'):
+        #     total_steps = int(gpc.config.num_epochs * len(train_dataloader))
+        # else:
+        #     raise Exception(
+        #         'Please specify training stopping criterion num_steps or num_epochs in your configuration.'
+        #     )
+        lr_scheduler = build_lr_scheduler(gpc.config.lr_scheduler, optimizer)
         logger.info('Learning rate scheduler is created', ranks=[0])
 
     # pipeline or no pipeline schedule

--- a/colossalai/trainer/_trainer.py
+++ b/colossalai/trainer/_trainer.py
@@ -147,6 +147,7 @@ class Trainer:
             if self.exceed_max_step():
                 # stop when max iter is reached
                 break
+        self._engine.complete()
         self._timer.stop('train-epoch', keep_in_history=True)
         self.call_hooks('after_train_epoch')
         self._timer.reset('train-step')

--- a/configs/vit/vit_2d.py
+++ b/configs/vit/vit_2d.py
@@ -8,10 +8,10 @@ BATCH_SIZE = 512
 IMG_SIZE = 32
 PATCH_SIZE = 4
 DIM = 512
-NUM_ATTENTION_HEADS = 8
+NUM_ATTENTION_HEADS = 2
 SUMMA_DIM = 2
 NUM_CLASSES = 10
-DEPTH = 6
+DEPTH = 1
 
 train_data = dict(
     dataset=dict(
@@ -127,14 +127,14 @@ hooks = [
     dict(type='LogMetricByEpochHook'),
     dict(type='Accuracy2DHook'),
     dict(type='LossHook'),
-    dict(type='TensorboardHook', log_dir='./tfb_logs'),
+    # dict(type='TensorboardHook', log_dir='./tfb_logs'),
     # dict(type='SaveCheckpointHook', interval=5, checkpoint_dir='./ckpt'),
     # dict(type='LoadCheckpointHook', epoch=20, checkpoint_dir='./ckpt')
 ]
 
 parallel = dict(
     pipeline=dict(size=1),
-    tensor=dict(size=4, mode='2d'),
+    tensor=dict(size=1, mode='2d'),
 )
 
 # for fp16 training
@@ -146,7 +146,8 @@ parallel = dict(
 
 lr_scheduler = dict(
     type='LinearWarmupLR',
-    warmup_epochs=5
+    total_steps=60,
+    warmup_steps=5
 )
 
 # only needed when pipeline parallel is used

--- a/examples/run_trainer.py
+++ b/examples/run_trainer.py
@@ -17,7 +17,8 @@ def run_trainer():
         criterion=criterion,
         optimizer=optimizer,
         lr_scheduler=lr_scheduler,
-        schedule=schedule
+        schedule=schedule,
+        gradient_accumulation=5,
     )
     logger.info("engine is built", ranks=[0])
 


### PR DESCRIPTION
- Added gradient accumulation in Engine which can be control by the parameter 'gradient_accumulation'. 
- Changed the way learning rate scheduler to update. Users can control learning rate scheduler in Engine by parameter 'lr_scheduler_step' to update learning rate with steps or epochs. 
- But users need to specify total steps and warm up steps in configuration file.