### PR TITLE
fix zero3 fp16 and add zero3 model context

### DIFF
--- a/colossalai/utils/__init__.py
+++ b/colossalai/utils/__init__.py
@@ -22,5 +22,5 @@ __all__ = ['checkpoint',
            'Timer', 'MultiTimer',
            'multi_tensor_applier',
            'accumulate_gradient',
-           'DataParallelSampler', 'get_dataloader'
+           'DataParallelSampler', 'get_dataloader',
            ]

--- a/colossalai/utils/common.py
+++ b/colossalai/utils/common.py
@@ -164,7 +164,8 @@ def clip_grad_norm_fp32(parameters, max_norm, norm_type=2):
         no_tensor_parallel_grads = []
         for p in params:
             if is_model_parallel_parameter(p):
-                reductor = (gpc.get_world_size(ParallelMode.TENSOR) / getattr(p, NUM_PARTITIONS)) ** (1 / norm_type)
+                reductor = (gpc.get_world_size(ParallelMode.TENSOR) /
+                            getattr(p, NUM_PARTITIONS)) ** (1 / norm_type)
                 tensor_parallel_grads.append(p.grad.data / reductor)
             else:
                 no_tensor_parallel_grads.append(p.grad.data)

--- a/colossalai/zero/__init__.py
+++ b/colossalai/zero/__init__.py
@@ -1,7 +1,10 @@
+import torch
 import torch.nn as nn
 from torch.optim import Optimizer
 from colossalai.amp.naive_amp import NaiveAMPModel
 from colossalai.utils import is_no_pp_or_last_stage
+from colossalai.core import global_context as gpc
+from colossalai.context.parallel_mode import ParallelMode
 
 from .zero_redundancy_optimizer_level_2 import ZeroRedundancyOptimizer_Level_2
 from .zero_redundancy_optimizer_level_3 import ZeroRedundancyOptimizer_Level_3
@@ -12,17 +15,43 @@ def convert_to_zero(model: nn.Module,
                     level: int,
                     zero_config):
     assert level == 2 or level == 3, 'Only ZERO Optimizer Level 2 and 3 are provided'
-
-    if is_no_pp_or_last_stage():
-        model = NaiveAMPModel(model, output_to_fp32=True)
-    else:
-        model = NaiveAMPModel(model, output_to_fp32=False)
+    if level == 2:
+        if is_no_pp_or_last_stage():
+            model = NaiveAMPModel(model, output_to_fp32=True)
+        else:
+            model = NaiveAMPModel(model, output_to_fp32=False)
 
     if level == 2:
-        optimizer = ZeroRedundancyOptimizer_Level_2(init_optimizer=optimizer, **zero_config)
+        optimizer = ZeroRedundancyOptimizer_Level_2(
+            init_optimizer=optimizer, **zero_config)
     else:
-        optimizer = ZeroRedundancyOptimizer_Level_3(init_optimizer=optimizer, module=model, **zero_config)
+        optimizer = ZeroRedundancyOptimizer_Level_3(
+            init_optimizer=optimizer, module=model, **zero_config)
     return model, optimizer
 
 
-__all__ = ['convert_to_zero', 'ZeroRedundancyOptimizer_Level_2', 'ZeroRedundancyOptimizer_Level_3']
+def zero3_model_context(dtype=torch.half):
+    assert dtype == torch.half or dtype == torch.float, f'Invalid dtype, except torch.half or torch.float, got {dtype}'
+    import deepspeed
+    ds_config = {
+        "train_micro_batch_size_per_gpu": 1,
+        "gradient_accumulation_steps": 1,
+        "zero_optimization": {
+            "offload_param": getattr(gpc.config.zero, 'offload_param_config', None),
+            "offload_optimizer": getattr(gpc.config.zero, 'offload_optimizer_config'),
+        },
+        "aio": getattr(gpc.config.zero, 'aio_config', None)
+    }
+    remote_device = getattr(
+        ds_config['zero_optimization']['offload_param'], 'device', None)
+    pin_memory = getattr(
+        ds_config['zero_optimization']['offload_param'], 'pin_memory', False)
+    return deepspeed.zero.Init(data_parallel_group=gpc.get_group(ParallelMode.DATA),
+                               remote_device=remote_device,
+                               config_dict_or_path=ds_config,
+                               pin_memory=pin_memory,
+                               dtype=dtype)
+
+
+__all__ = ['convert_to_zero', 'ZeroRedundancyOptimizer_Level_2',
+           'ZeroRedundancyOptimizer_Level_3', 'zero3_model_context']

--- a/colossalai/zero/zero_redundancy_optimizer_level_3.py
+++ b/colossalai/zero/zero_redundancy_optimizer_level_3.py
@@ -637,7 +637,8 @@ class ZeroRedundancyOptimizer_Level_3(Optimizer):
                  postscale_gradients=True,
                  gradient_predivide_factor=1.0,
                  gradient_accumulation_steps=1,
-                 aio_config=None):
+                 aio_config=None,
+                 dtype=torch.half):
         # mpu = None
         # mpu is removed from the parameter list
         # tensor parallel will be automatically detected later
@@ -682,13 +683,25 @@ class ZeroRedundancyOptimizer_Level_3(Optimizer):
         util_ops = UtilsBuilder().load()
         self.flatten = util_ops.flatten
         self.unflatten = util_ops.unflatten
-        self.dtype = self.optimizer.param_groups[0]['params'][0].dtype
+        self.dtype = dtype
 
         if not all(is_zero_param(p) for p in module.parameters()):
+            ds_config = {
+                "train_micro_batch_size_per_gpu": 1,
+                "gradient_accumulation_steps": 1,
+                "zero_optimization": {
+                    "offload_param": offload_param_config,
+                    "offload_optimizer": offload_optimizer_config,
+                },
+                "aio": aio_config
+            }
+            remote_device = offload_param_config['device']
             group = None
             if gpc.is_initialized(ParallelMode.DATA):
                 group = gpc.get_group(ParallelMode.DATA)
-            Init(module=module, data_parallel_group=group, dtype=self.dtype)
+            Init(module=module, data_parallel_group=group, dtype=self.dtype,
+                 remote_device=remote_device, config_dict_or_path=ds_config, pin_memory=offload_optimizer_config[
+                     OFFLOAD_OPTIMIZER_PIN_MEMORY])
 
         for m in module.modules():
             _init_external_params(m)


### PR DESCRIPTION
1. ZeRO3 doesn't use NaiveAMP
2. ZeRO3 doesn't sync parameters over data parallel process group
3. Provide a context to build massive models when using ZeRO3