### PR TITLE
Add interleaved pipeline and fix naive amp

### DIFF
--- a/colossalai/amp/naive_amp/_fp16_optimizer.py
+++ b/colossalai/amp/naive_amp/_fp16_optimizer.py
@@ -14,7 +14,7 @@ from colossalai.context.parallel_mode import ParallelMode
 from colossalai.core import global_context as gpc
 from colossalai.logging import get_dist_logger
 from colossalai.utils import (print_rank_0, copy_tensor_parallel_attributes,
-                              clip_grad_norm_fp32, count_zeros_fp32, multi_tensor_applier)
+                              clip_grad_norm_fp32, count_zeros_fp32, multi_tensor_applier, is_using_pp)
 
 
 def _zero_grad_group_helper(group, set_to_none):
@@ -58,7 +58,8 @@ class DynamicGradScaler:
                  backoff_factor,
                  growth_interval,
                  hysteresis,
-                 max_scale: int = None):
+                 max_scale: int = None,
+                 verbose: bool = False):
         """"Grad scaler with dynamic scale that gets adjusted
         during training."""
         assert initial_scale > 0.0
@@ -91,6 +92,7 @@ class DynamicGradScaler:
         self._hysteresis_tracker = self.hysteresis
 
         self._logger = get_dist_logger()
+        self.verbose = verbose
 
     @property
     def scale(self):
@@ -111,7 +113,8 @@ class DynamicGradScaler:
             if self._hysteresis_tracker <= 0:
                 self._scale = torch.max(self._scale * self.backoff_factor,
                                         self.min_scale)
-            self._logger.info(f'overflow occurs, loss scale is adjusted to {self._scale}', ranks=[0])
+            if self.verbose:
+                self._logger.info(f'overflow occurs, loss scale is adjusted to {self._scale}', ranks=[0])
         else:
             # If there is no nan/inf, increment the growth tracker.
             self._growth_tracker += 1
@@ -122,11 +125,14 @@ class DynamicGradScaler:
                 self._hysteresis_tracker = self.hysteresis
                 # and scale up the loss scale.
                 if self._max_scale is not None and self._scale >= self._max_scale:
-                    self._logger.info(
-                        f'Current loss scale {self._scale} has reached the max scale {self._max_scale} allowed', ranks=[0])
+                    if self.verbose:
+                        self._logger.info(
+                            f'Current loss scale {self._scale} has reached the max scale {self._max_scale} allowed', ranks=[0])
                 else:
                     self._scale = self._scale * self.growth_factor
-                    self._logger.info(f'no consecutive overflow, loss scale is adjusted to {self._scale}', ranks=[0])
+                    if self.verbose:
+                        self._logger.info(
+                            f'no consecutive overflow, loss scale is adjusted to {self._scale}', ranks=[0])
 
     def state_dict(self):
         state_dict = {}
@@ -162,6 +168,8 @@ class FP16Optimizer(Optimizer):
     :type hysterisis: int
     :param max_scale: maximum loss scale allowed
     :type max_scale: int
+    :param verbose: if set to `True`, will print debug info
+    :type verbose: bool
     """
 
     def __init__(self,
@@ -174,27 +182,29 @@ class FP16Optimizer(Optimizer):
                  backoff_factor=0.5,
                  growth_interval=1000,
                  hysteresis=2,
-                 max_scale: int = 2 ** 32):
+                 max_scale: int = 2 ** 32,
+                 verbose: bool = False):
         # default args for compatibility
         bf16 = False
-        params_have_main_grad = True
+        params_have_main_grad = False
 
         # have a defaults for compatibility with pytorch optim
         self.defaults = optimizer.defaults
 
         # log config
         self._logger = get_dist_logger()
-        self._logger.info(f"\n=========  FP16 Optimizer Config =========\n"
-                          f"Optimizer: {optimizer.__class__.__name__}\n"
-                          f"clip_grad = {clip_grad}\n"
-                          f"log_num_zeros_in_grad = {log_num_zeros_in_grad}\n"
-                          f"initial_scale = {initial_scale}\n"
-                          f"min_scale = {min_scale}\n"
-                          f"growth_factor = {growth_factor}\n"
-                          f"backoff_factor = {backoff_factor}\n"
-                          f"growth_interval = {growth_interval}\n"
-                          f"hysteresis = {hysteresis}\n"
-                          f"==========================================", ranks=[0])
+        if verbose:
+            self._logger.info(f"\n=========  FP16 Optimizer Config =========\n"
+                              f"Optimizer: {optimizer.__class__.__name__}\n"
+                              f"clip_grad = {clip_grad}\n"
+                              f"log_num_zeros_in_grad = {log_num_zeros_in_grad}\n"
+                              f"initial_scale = {initial_scale}\n"
+                              f"min_scale = {min_scale}\n"
+                              f"growth_factor = {growth_factor}\n"
+                              f"backoff_factor = {backoff_factor}\n"
+                              f"growth_interval = {growth_interval}\n"
+                              f"hysteresis = {hysteresis}\n"
+                              f"==========================================", ranks=[0])
 
         """Input optimizer is the base optimizer for example Adam."""
         self.optimizer = optimizer
@@ -212,7 +222,8 @@ class FP16Optimizer(Optimizer):
             backoff_factor=backoff_factor,
             growth_interval=growth_interval,
             hysteresis=hysteresis,
-            max_scale=max_scale
+            max_scale=max_scale,
+            verbose=verbose
         )
 
         # None grad scaler is only supported for bf16.
@@ -349,6 +360,11 @@ class FP16Optimizer(Optimizer):
         torch.distributed.all_reduce(self.found_inf,
                                      op=torch.distributed.ReduceOp.MAX,
                                      group=gpc.get_group(ParallelMode.TENSOR))
+
+        if is_using_pp():
+            torch.distributed.all_reduce(self.found_inf,
+                                         op=torch.distributed.ReduceOp.MAX,
+                                         group=gpc.get_group(ParallelMode.PIPELINE))
 
         # Check for nan.
         found_inf_flag = (self.found_inf.item() > 0)

--- a/colossalai/builder/__init__.py
+++ b/colossalai/builder/__init__.py
@@ -1,10 +1,10 @@
 from .builder import (build_schedule, build_lr_scheduler, build_model, build_optimizer, build_layer,
                       build_loss, build_hooks, build_dataset, build_transform, build_data_sampler,
                       build_gradient_handler)
-from .pipeline import PipelineModelInitializer
+from .pipeline import build_pipeline_model, build_pipeline_model_from_cfg
 
 __all__ = [
     'build_schedule', 'build_lr_scheduler', 'build_model', 'build_optimizer',
     'build_layer', 'build_loss', 'build_hooks', 'build_dataset', 'build_transform', 'build_data_sampler',
-    'build_gradient_handler', 'PipelineModelInitializer'
+    'build_gradient_handler', 'build_pipeline_model', 'build_pipeline_model_from_cfg'
 ]

--- a/colossalai/builder/pipeline.py
+++ b/colossalai/builder/pipeline.py
@@ -1,11 +1,12 @@
 import copy
 import heapq
 
+
 from colossalai.builder import build_model, build_layer
 from colossalai.context.parallel_mode import ParallelMode
 from colossalai.core import global_context as gpc
 from colossalai.logging import get_dist_logger
-from colossalai.utils import set_to_cuda
+import torch.nn as nn
 
 
 def _binary_partition(weights, st, ed):
@@ -150,7 +151,19 @@ def _partition_balanced(weights, pipeline_parallel_size, num_chunks):
     return parts
 
 
-class PipelineModelInitializer():
+def _count_layer_params(layers):
+    """Count the number of parameters in each layer
+    """
+    param_counts = [0] * len(layers)
+    for idx, cfg in enumerate(layers):
+        layer = build_layer(cfg)
+        params = filter(lambda p: p.requires_grad, layer.parameters())
+        param_counts[idx] = sum(p.numel() for p in params)
+
+    return param_counts
+
+
+def build_pipeline_model_from_cfg(config, num_chunks: int = 1, partition_method: str = 'parameter', verbose: bool = False):
     """An intializer to split the model into different stages for pipeline parallelism.
 
     An example for the model config is shown below. The class VisionTransformerFromConfig should
@@ -168,88 +181,86 @@ class PipelineModelInitializer():
     :param num_chunks: the number of chunks you want to have on the current stage. This value should be 1
                         in most cases unless you are using virutal pipeline parallelism.
     :type num_chunks: int
+    :param partition_method: this parameter determines how you want to split your model layers into stages,
+                                you can set it as 'layer' or 'parameter'
+    :type partition_method: str
     :param verbose: whether to print the logs
     :type verbose: bool
-
     """
+    ori_model = build_model(config)
+    layers = ori_model.layers_cfg
+    layer_length = len(layers)
+    logger = get_dist_logger()
+    if verbose:
+        logger.info(f"The total length of layers is {layer_length}", ranks=[0])
 
-    def __init__(self, config, num_chunks, verbose=False):
-        self.num_chunks = num_chunks
-        self.ori_model = build_model(config)
-        self.layers = self.ori_model.layers_cfg
-        layer_length = len(self.layers)
-        self.verbose = verbose
-        self._logger = get_dist_logger()
-        self._logger.info(f"The total length of layers is {layer_length}", ranks=[0])
+    pipeline_parallel_size = gpc.get_world_size(ParallelMode.PIPELINE)
+    pipeline_rank = gpc.get_local_rank(ParallelMode.PIPELINE)
 
-    def initialize(self, partition_method='parameter'):
-        """Initialize the model object from the config passed
+    method = partition_method.lower()
+    # Make a partition
+    if method == 'layer':
+        num_layers = len(layers)
+        parts = _partition_uniform(num_layers, pipeline_parallel_size, num_chunks)
+    elif method == 'parameter':
+        param_counts = _count_layer_params(layers)
+        # print_rank_0(param_counts)
+        parts = _partition_balanced(param_counts, pipeline_parallel_size, num_chunks)
+    else:
+        raise ValueError("Method should be a pre-set string in [layer, parameter]")
 
-        :param partition_method: this parameter determines how you want to split your model layers into stages,
-                                you can set it as 'layer' or 'parameter'
-        :type partition_method: str
-        
-        """
-        # Some space for initializing comunication groups
-        self._interval = None
-        self._partition_layers(method=partition_method)
-        models = self._build()
-        model = set_to_cuda(models)
+    # Display the partition
+    if verbose:
+        log_str = 'Layer allocation after partitioning: \n'
+        for stage in range(pipeline_parallel_size):
 
-        return model
+            num_layers = 0
+            for st, ed in parts[stage]:
+                num_layers += ed - st
 
-    def _partition_layers(self, method):
-        pipeline_parallel_size = gpc.get_world_size(ParallelMode.PIPELINE)
-        pipeline_rank = gpc.get_local_rank(ParallelMode.PIPELINE)
+            log_str += f'\n===== stage={stage}, layers={num_layers} =====\n'
+            for st, ed in parts[stage]:
+                for idx, layer in enumerate(layers[st: ed]):
+                    log_str += f'\t{idx + st:2d}: {layer}\n'
+        logger.info(log_str, ranks=[0])
 
-        method = method.lower()
-        # Make a partition
-        if method == 'layer':
-            num_layers = len(self.layers)
-            self.parts = _partition_uniform(num_layers, pipeline_parallel_size, self.num_chunks)
-        elif method == 'parameter':
-            param_counts = self._count_layer_params()
-            # print_rank_0(param_counts)
-            self.parts = _partition_balanced(param_counts, pipeline_parallel_size, self.num_chunks)
-        else:
-            raise ValueError("Method should be a pre-set string in [layer, parameter]")
+    # Save the partition
+    interval = parts[pipeline_rank]
 
-        # Display the partition
-        if gpc.get_global_rank() == 0 and self.verbose:
-            log_str = 'Layer allocation after partitioning: \n'
-            for stage in range(pipeline_parallel_size):
+    models = []
+    for st, ed in interval:
+        model = copy.deepcopy(ori_model)
+        model.build_from_cfg(st, ed)
+        models.append(model)
 
-                num_layers = 0
-                for st, ed in self.parts[stage]:
-                    num_layers += ed - st
+    return nn.ModuleList(models) if len(models) > 1 else models[0]
 
-                log_str += f'\n===== stage={stage}, layers={num_layers} =====\n'
-                for st, ed in self.parts[stage]:
-                    for idx, layer in enumerate(self.layers[st: ed]):
-                        log_str += f'\t{idx + st:2d}: {layer}\n'
-            self._logger.info(log_str, ranks=[0])
 
-        # Save the partition
-        self._interval = self.parts[pipeline_rank]
+def build_pipeline_model(layers: nn.Sequential, num_chunks: int = 1, verbose: bool = False):
+    """An intializer to split the model into different stages for pipeline parallelism.
+    Note that `layer` must be `torch.nn.Sequential`.
 
-    def _build(self):
-        """Build model from the layer cfg according to the partition
-        """
-        models = []
-        for st, ed in self._interval:
-            model = copy.copy(self.ori_model)
-            model.build_from_cfg(st, ed)
-            models.append(model)
-
-        return models
-
-    def _count_layer_params(self):
-        """Count the number of parameters in each layer
-        """
-        param_counts = [0] * len(self.layers)
-        for idx, cfg in enumerate(self.layers):
-            layer = build_layer(cfg)
-            params = filter(lambda p: p.requires_grad, layer.parameters())
-            param_counts[idx] = sum(p.numel() for p in params)
-
-        return param_counts
+    :param layers: layers of model
+    :type config: `torch.nn.Sequential`
+    :param num_chunks: the number of chunks you want to have on the current stage. This value should be 1
+                        in most cases unless you are using virutal pipeline parallelism.
+    :type num_chunks: int
+    :param verbose: whether to print the logs
+    :type verbose: bool
+    """
+    pipeline_parallel_size = gpc.get_world_size(ParallelMode.PIPELINE)
+    pipeline_rank = gpc.get_local_rank(ParallelMode.PIPELINE)
+    partitions = _partition_uniform(len(layers), pipeline_parallel_size, num_chunks)
+    module_list = []
+    for start, end in partitions[pipeline_rank]:
+        module_list.append(nn.Sequential(*layers[start:end]))
+    if verbose:
+        logger = get_dist_logger()
+        logger.info(f'Total {len(layers)} layers', ranks=[0])
+        for rank, part in enumerate(partitions):
+            log_str = f'===== stage={rank} =====\n'
+            for chunk, (start, end) in enumerate(part):
+                log_str += f'===== chunk={chunk}, layer=[{start}-{end}] =====\n'
+                log_str += '\n'.join([str(layer) for layer in layers[start:end]]) + '\n'
+            logger.info(log_str, ranks=[0])
+    return nn.ModuleList(module_list) if len(module_list) > 1 else module_list[0]

--- a/colossalai/communication/utils.py
+++ b/colossalai/communication/utils.py
@@ -29,14 +29,8 @@ def send_tensor_meta(tensor, need_meta=True, next_rank=None):
 
         send_shape = torch.tensor(tensor.size(), **tensor_kwargs)
         send_ndims = torch.tensor(len(tensor.size()), **tensor_kwargs)
-        ops = [
-            dist.P2POp(dist.isend, send_ndims, next_rank),
-            dist.P2POp(dist.isend, send_shape, next_rank)
-        ]
-        reqs = dist.batch_isend_irecv(ops)
-        for req in reqs:
-            req.wait()
-        torch.cuda.synchronize()
+        dist.send(send_ndims, next_rank)
+        dist.send(send_shape, next_rank)
 
     return False
 

--- a/colossalai/engine/gradient_handler/_data_parallel_gradient_handler.py
+++ b/colossalai/engine/gradient_handler/_data_parallel_gradient_handler.py
@@ -32,7 +32,7 @@ class DataParallelGradientHandler(BaseGradientHandler):
                     if tp not in buckets:
                         buckets[tp] = []
                     buckets[tp].append(param)
-                    param.main_grad = param.grad
+                    # param.main_grad = param.grad
 
             # For each bucket, all-reduce and copy all-reduced grads.
             for tp in buckets:

--- a/colossalai/engine/schedule/__init__.py
+++ b/colossalai/engine/schedule/__init__.py
@@ -1,5 +1,5 @@
 from ._base_schedule import BaseSchedule
-from ._pipeline_schedule import PipelineSchedule
+from ._pipeline_schedule import PipelineSchedule, InterleavedPipelineSchedule
 from ._non_pipeline_schedule import NonPipelineSchedule
 
-__all__ = ['BaseSchedule', 'PipelineSchedule', 'NonPipelineSchedule']
+__all__ = ['BaseSchedule', 'PipelineSchedule', 'NonPipelineSchedule', 'InterleavedPipelineSchedule']

--- a/colossalai/utils/__init__.py
+++ b/colossalai/utils/__init__.py
@@ -3,7 +3,7 @@ from .common import (print_rank_0, sync_model_param_in_dp, is_dp_rank_0,
                      is_tp_rank_0, is_no_pp_or_last_stage, is_using_ddp,
                      is_using_pp, conditional_context, is_model_parallel_parameter,
                      clip_grad_norm_fp32, count_zeros_fp32, copy_tensor_parallel_attributes,
-                     param_is_not_tensor_parallel_duplicate)
+                     param_is_not_tensor_parallel_duplicate, switch_virtual_pipeline_parallel_rank)
 from .cuda import get_current_device, synchronize, empty_cache, set_to_cuda
 from .memory import report_memory_usage
 from .timer import MultiTimer, Timer
@@ -22,5 +22,6 @@ __all__ = ['checkpoint',
            'Timer', 'MultiTimer',
            'multi_tensor_applier',
            'accumulate_gradient',
-           'DataParallelSampler', 'get_dataloader'
+           'DataParallelSampler', 'get_dataloader',
+           'switch_virtual_pipeline_parallel_rank'
            ]

--- a/colossalai/utils/common.py
+++ b/colossalai/utils/common.py
@@ -249,3 +249,13 @@ def param_is_not_tensor_parallel_duplicate(param):
     return (hasattr(param, IS_TENSOR_PARALLEL) and
             getattr(param, IS_TENSOR_PARALLEL)) or (
         gpc.get_local_rank(ParallelMode.TENSOR) == 0)
+
+
+@contextmanager
+def switch_virtual_pipeline_parallel_rank(rank):
+    prev_rank = gpc.virtual_pipeline_parallel_rank
+    try:
+        gpc.set_virtual_pipeline_parallel_rank(rank)
+        yield
+    finally:
+        gpc.set_virtual_pipeline_parallel_rank(prev_rank)

--- a/docs/parallelization.md
+++ b/docs/parallelization.md
@@ -172,10 +172,10 @@ elif gpc.get_local_rank(ParallelMode.PIPELINE) == 1:
 2. Make sure your model inherit `colossalai.nn.model.ModelFromConfig` and registered into the
 `MODELS` registry. Define the `self.layers_cfg` attribute. 
 Pass in a dict/Config object which specifies the parameters of your model. 
-Use `colossalai.builder.pipeline.PipelineModelInitializer` to partition the layers.
+Use `colossalai.builder.pipeline.build_pipeline_model_from_cfg` to partition the layers.
 
 ```python
-from colossalai.builder import PipelineModelInitializer
+from colossalai.builder import build_pipeline_model_from_cfg
 from colossalai.nn.model import ModelFromConfig
 from colossalai.registry import MODELS
 
@@ -199,8 +199,11 @@ model_cfg = dict(
     ...
 )
 
-initializer = PipelineModelInitializer(model_cfg, num_chunks=1)
-model = initializer.initialize()
+# from config 
+model = build_pipeline_model_from_cfg(model_cfg, num_chunks=1)
+
+# from torch.nn.Sequential
+# model = build_pipeline_model(sequential_model, num_model_chunks)
 
 ```
 
@@ -213,6 +216,9 @@ from colossalai.engine.schedule import PipelineSchedule
 engine, train_dataloader, _, _ = colossalai.initialize(model, optimizer, criterion, train_dataloader) 
 
 schedule = PipelineSchedule(num_microbatches=4)
+
+# interleaved pipeline
+# schedule = InterleavedPipelineSchedule(num_microbatches=4, num_model_chunks=2)
 
 # execute a training epoch
 data_iter = iter(train_dataloader)

--- a/tests/test_data_pipeline_tensor_parallel/run_cifar10_vit2d_with_pipeline.py
+++ b/tests/test_data_pipeline_tensor_parallel/run_cifar10_vit2d_with_pipeline.py
@@ -6,7 +6,7 @@ from colossalai.logging import get_dist_logger
 import colossalai
 import torch
 import os
-from colossalai.builder import PipelineModelInitializer
+from colossalai.builder import build_pipeline_model_from_cfg
 from colossalai.core import global_context as gpc
 from colossalai.utils import get_dataloader, MultiTimer
 from colossalai.nn.loss import CrossEntropyLoss2D
@@ -50,8 +50,7 @@ def test_hybrid_parallel():
     #                        suffix='cifar10_2d_vit_ddp1_torch_amp_grad_accum_2_clip_grad_1', mode='w')
 
     # build vit-t-32
-    initializer = PipelineModelInitializer(vit_t_2d.model_cfg, num_chunks=1)
-    model = initializer.initialize()
+    model = build_pipeline_model_from_cfg(vit_t_2d.model_cfg, num_chunks=1)
 
     # build dataloaders
     train_dataset = CIFAR10(
@@ -139,4 +138,4 @@ def test_hybrid_parallel():
 
 
 if __name__ == '__main__':
-    main()
+    test_hybrid_parallel()

--- a/tests/test_trainer/test_pipeline/test_partition.py
+++ b/tests/test_trainer/test_pipeline/test_partition.py
@@ -5,7 +5,7 @@ import torch
 import torch.multiprocessing as mp
 from torch.utils.data import DataLoader
 
-from colossalai.builder.pipeline import PipelineModelInitializer
+from colossalai.builder.pipeline import build_pipeline_model_from_cfg
 from colossalai.core import global_context
 from colossalai.initialize import launch
 from colossalai.logging import get_dist_logger
@@ -28,7 +28,7 @@ def run_partition(rank, world_size):
     logger.info('finished initialization')
 
     # build model
-    model = PipelineModelInitializer(global_context.config.model, 1, verbose=True).initialize()
+    model = build_pipeline_model_from_cfg(global_context.config.model, 1, verbose=True)
     assert isinstance(model, torch.nn.Module)
     logger.info('model is created')
 

--- a/tests/test_trainer/test_pipeline/test_pipeline_schedule.py
+++ b/tests/test_trainer/test_pipeline/test_pipeline_schedule.py
@@ -8,7 +8,7 @@ import torch
 import torch.multiprocessing as mp
 import model
 
-from colossalai.builder import PipelineModelInitializer
+from colossalai.builder import build_pipeline_model_from_cfg
 from colossalai.communication import p2p as p2p_communication
 from colossalai.communication.utils import send_tensor_meta, recv_tensor_meta
 from colossalai.context.parallel_mode import ParallelMode
@@ -39,7 +39,7 @@ def run_schedule(rank, world_size):
            backend='nccl')
 
     # build model
-    model = PipelineModelInitializer(gpc.config.model, 1).initialize()
+    model = build_pipeline_model_from_cfg(gpc.config.model, 1)
     print_rank_0('model is created')
 
     train_dataset = CIFAR10(


### PR DESCRIPTION
# Overview
1. We add interleaved pipeline schedule. 
2. Update pipeline model initializer.
3. Fix Naive AMP

# Interleaved pipeline schedule and pipeline model initializer
We kept the original `PipelineModelInitializer`, but renamed it `to build_pipeline_model_from_cfg`. We add a new function to build the pipeline parallel model: `build_pipeline_model`. User must pass a `torch.nn.Sequential` to this function.

Usage:
```python
from colossalai.engine.schedule import InterleavedPipelineSchedule
from colossalai.builder import build_pipeline_model_from_cfg, build_pipeline_model

# from config
model = build_pipeline_model_from_cfg(model_cfg, num_model_chunks)

# from torch.nn.Sequential
model = build_pipeline_model(sequential_model, num_model_chunks)

schedule = InterleavedPipelineSchedule(num_microbatches, num_model_chunks)
```

`build_pipeline_model` and `build_pipeline_model_from_cfg` can also receive a key word argument `verbose`. The detail of layers in each rank will be printed if setting `verbose` to `True`.

# Fix Naive AMP
The old Naive AMP didn't apply all-reduce over pipeline parallel process group when computing infinity values, which leads to a hang. I fixed this bug, so that both pipeline parallelism and interleaved pipeline parallelism with Naive AMP won't get stuck again. Note that the pipeline parallelism **only** support **Naive AMP** now.
