### PR TITLE
update default logger (#100)

### DIFF
--- a/colossalai/context/config.py
+++ b/colossalai/context/config.py
@@ -5,6 +5,7 @@ import inspect
 import sys
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
+from colossalai.logging import get_dist_logger
 
 
 class Config(dict):
@@ -88,8 +89,8 @@ class Config(dict):
             else:
                 config._add_item(k, v)
 
-        # TODO: replace with logger warning here when logger is done
-        print('warning: variables which starts with __, is a module or class declaration are omitted')
+        logger = get_dist_logger()
+        logger.debug('variables which starts with __, is a module or class declaration are omitted in config file')
 
         # remove module
         del sys.modules[module_name]

--- a/colossalai/logging/__init__.py
+++ b/colossalai/logging/__init__.py
@@ -1,9 +1,11 @@
+from typing import List
 from .logging import DistributedLogger
+import logging
 
 __all__ = ['get_dist_logger', 'DistributedLogger']
 
 
-def get_dist_logger(name='root'):
+def get_dist_logger(name='colossalai'):
     """Get logger instance based on name. The DistributedLogger will create singleton instances,
     which means that only one logger instance is created per name.
 
@@ -14,3 +16,14 @@ def get_dist_logger(name='root'):
     :rtype: :class:`colossalai.logging.DistributedLogger`
     """
     return DistributedLogger.get_instance(name=name)
+
+
+def disable_existing_loggers(except_loggers: List[str] = ['colossalai']):
+    """Set the level of existing loggers to `WARNING`.
+
+    :param except_loggers: loggers in this `list` will be ignored when disabling, defaults to ['colossalai']
+    :type except_loggers: list, optional
+    """
+    for log_name in logging.Logger.manager.loggerDict.keys():
+        if log_name not in except_loggers:
+            logging.getLogger(log_name).setLevel(logging.WARNING)


### PR DESCRIPTION
1. Replace the default logger name 'root' with 'colossalai'
2. Add `disable_existing_loggers()`. Call this function before `colossalai.launch()` to disable existing loggers (e.g. torch.distributed.distributed_c10d).