### PR TITLE
pipeline last stage supports multi output

### DIFF
--- a/tests/test_trainer/test_pipeline/model/resnet.py
+++ b/tests/test_trainer/test_pipeline/model/resnet.py
@@ -139,7 +139,7 @@ class VanillaResNet(ModelFromConfig):
     def forward(self, x: Tensor):
         for layer in self.layers:
             x = layer(x)
-        return x,
+        return x
 
     def init_weights(self):
         for m in self.modules():


### PR DESCRIPTION
Pipeline parallelism supports multi outputs and labels now. We also log the tensor shape and dtype of the output of model when using pipeline, and set the logging level to DEBUG to print.