### PR TITLE
removed jit default setting

### DIFF
--- a/colossalai/kernel/jit/__init__.py
+++ b/colossalai/kernel/jit/__init__.py
@@ -1,8 +1,8 @@
-from .option import _set_jit_fusion_options
+from .option import set_jit_fusion_options
 from .bias_dropout_add import bias_dropout_add_fused_train, bias_dropout_add_fused_inference
 from .bias_gelu import bias_gelu_impl
-_set_jit_fusion_options()
 
 __all__ = [
     "bias_dropout_add_fused_train", "bias_dropout_add_fused_inference", "bias_gelu_impl",
+    "set_jit_fusion_options"
 ]

--- a/colossalai/kernel/jit/option.py
+++ b/colossalai/kernel/jit/option.py
@@ -3,8 +3,11 @@ import torch
 JIT_OPTIONS_SET = False
 
 
-def _set_jit_fusion_options():
-    """Set PyTorch JIT layer fusion options."""
+def set_jit_fusion_options():
+    """Set PyTorch JIT layer fusion options.
+    """
+    # LSG: the latest pytorch and CUDA versions may not support 
+    # the following jit settings
     global JIT_OPTIONS_SET
     if JIT_OPTIONS_SET == False:
         # flags required to enable jit fusion kernels


### PR DESCRIPTION
The original code will set jit fusion options by default. However, these options may not work on the latest PyTorch and CUDA version. We tested these options on A100 and performance can be worse compared to the case where no jit fusion is set. Thus, jit fusion should be set to be optional and exposed to the user.