### PR TITLE
add a common util for hooks registered on parameter.

### DIFF
--- a/colossalai/engine/paramhooks/__init__.py
+++ b/colossalai/engine/paramhooks/__init__.py
@@ -1,0 +1,2 @@
+from ._base_paramhook import BaseParamHook
+__all__ = ["BaseParamHook"]

--- a/colossalai/engine/paramhooks/__init__.py
+++ b/colossalai/engine/paramhooks/__init__.py
@@ -1,2 +1,2 @@
-from ._base_paramhook import BaseParamHook
-__all__ = ["BaseParamHook"]
+from ._param_hookmgr import BaseParamHookMgr
+__all__ = ["BaseParamHookMgr"]

--- a/colossalai/engine/paramhooks/_base_paramhook.py
+++ b/colossalai/engine/paramhooks/_base_paramhook.py
@@ -1,5 +1,6 @@
 from typing import Callable, List
 import torch
+import functools
 
 class BaseParamHook(object):
     def __init__(self, param_list: List[torch.nn.Parameter]) -> None:
@@ -15,14 +16,14 @@ class BaseParamHook(object):
         is computed. 
         The hook should have the following signature:
         ```
-        hook(grad) -> Tensor or None
+        hook(param, grad) -> Tensor or None
         ```
         """
         if not torch.is_grad_enabled():
             return  # don't register grad hooks if grad isn't enabled
         for p in self._param_list:
             if p.requires_grad and not hasattr(p, '_base_param_hook'):
-                handle = p.register_hook(hook_call)
+                handle = p.register_hook(functools.partial(hook_call, p))
                 p._base_param_hook = handle
 
     def remove_hooks(self):

--- a/colossalai/engine/paramhooks/_base_paramhook.py
+++ b/colossalai/engine/paramhooks/_base_paramhook.py
@@ -1,0 +1,37 @@
+from typing import Callable, List
+import torch
+
+class BaseParamHook(object):
+    def __init__(self, param_list: List[torch.nn.Parameter], backward_hook_call: Callable) -> None:
+        r"""
+        register backward hook on every parameters of module
+        """
+        self.param_list = param_list
+        self._register_backward_hooks(backward_hook_call)
+
+    def _register_backward_hooks(self, hook_call : Callable) -> None:
+        r"""
+        The hook_call will be called every time a gradient with respect to the a param in self.param_list 
+        is computed. 
+        The hook should have the following signature:
+        ```
+        hook(grad) -> Tensor or None
+        ```
+        """
+        if not torch.is_grad_enabled():
+            return  # don't register grad hooks if grad isn't enabled
+        for p in self.param_list:
+            if p.requires_grad and not hasattr(p, 'zero_shard_bwd_hook'):
+                # For mixed precision with activation checkpoint, hooks on GradAccumulation won't be fired normally
+                # Instead we register hook on parameter
+                # In this way, we can't modify param.grad and param.data directly, which leads to more memory usage
+                # Register a hook on the first call, empirically, autograd
+                # fires it at the end for this param, which makes sense.
+                # p_tmp = p.expand_as(p)  # Get a grad_fn on p_tmp.
+                # assert p_tmp.grad_fn is not None
+                # grad_acc = p_tmp.grad_fn.next_functions[0][0]  # Gets its GradAccumulation object.
+                # handle = grad_acc.register_hook(functools.partial(self._post_backward_hook, p))
+                # p.zero_shard_bwd_hook = (grad_acc, handle)
+                # handle = p.register_hook(functools.partial(self._post_backward_hook, p))
+                handle = p.register_hook(hook_call)
+                p.zero_shard_bwd_hook = handle

--- a/colossalai/engine/paramhooks/_base_paramhook.py
+++ b/colossalai/engine/paramhooks/_base_paramhook.py
@@ -38,4 +38,5 @@ class BaseParamHook(object):
 
     def remove_hooks(self):
         for p in self.param_list:
-            p._base_param_hook.remove()
+            if p.requires_grad and hasattr(p, '_base_param_hook'):
+                p._base_param_hook.remove()

--- a/colossalai/engine/paramhooks/_param_hookmgr.py
+++ b/colossalai/engine/paramhooks/_param_hookmgr.py
@@ -2,7 +2,7 @@ from typing import Callable, List
 import torch
 import functools
 
-class BaseParamHook(object):
+class BaseParamHookMgr(object):
     def __init__(self, param_list: List[torch.nn.Parameter]) -> None:
         r"""
         register backward hook on every parameters of module

--- a/tests/test_engine/test_engine/test_param_hook.py
+++ b/tests/test_engine/test_engine/test_param_hook.py
@@ -1,5 +1,4 @@
 import pytest
-from tkinter import S
 from colossalai.engine.paramhooks import BaseParamHook
 from torch import nn
 import torch
@@ -70,6 +69,7 @@ def test_base_param_hook():
         loss.backward()
 
         if use_param_hook:
+            hook_mgr.remove_hooks()
             return hookwrapper.hook_triggered_times
     
     model_copy = copy.deepcopy(model)

--- a/tests/test_engine/test_engine/test_param_hook.py
+++ b/tests/test_engine/test_engine/test_param_hook.py
@@ -1,0 +1,87 @@
+import pytest
+from tkinter import S
+from colossalai.engine.paramhooks import BaseParamHook
+from torch import nn
+import torch
+import torch.nn.functional as F
+import copy
+import functools
+
+class SubNet(nn.Module):
+    def __init__(self, out_features) -> None:
+        super().__init__()
+        self.bias = nn.Parameter(torch.zeros(out_features))
+
+    def forward(self, x, weight):
+        return F.linear(x, weight, self.bias)
+
+
+class Net(nn.Module):
+    def __init__(self, checkpoint=False) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(5, 5)
+        self.sub_fc = SubNet(5)
+        self.fc2 = nn.Linear(5, 1)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.sub_fc(x, self.fc1.weight)
+        x = self.fc1(x)
+        x = self.fc2(x)
+        return x
+
+def net_data():
+    return (torch.randn(2, 5, dtype=torch.float, device='cuda'),)
+
+def allclose(tensor_a: torch.Tensor, tensor_b: torch.Tensor, loose=False) -> bool:
+    if loose:
+        return torch.allclose(tensor_a, tensor_b, atol=1e-3, rtol=1e-3)
+    return torch.allclose(tensor_a, tensor_b)
+
+
+def test_base_param_hook():
+    torch.manual_seed(0)
+    model = Net(checkpoint=True).cuda()
+    model.train()
+    inputs = net_data()
+
+    def run_model(model, inputs, use_param_hook = False):
+        if use_param_hook:
+            class HooKWrapper:
+                def __init__(self) -> None:
+                    self.hook_triggered_times = 0
+
+                def wrapper_func(self):
+                    def hook(grad) -> torch.Tensor or None:
+                        self.hook_triggered_times += 1
+                        return grad
+                    return hook
+
+            hookwrapper = HooKWrapper()
+            param_list = [p for p in model.parameters()]
+            BaseParamHook(param_list, hookwrapper.wrapper_func())
+
+        
+        model.zero_grad(set_to_none=True)
+
+        with torch.cuda.amp.autocast():
+            y = model(*inputs)
+            loss = y.sum()
+        loss.backward()
+
+        if use_param_hook:
+            return hookwrapper.hook_triggered_times
+    
+    model_copy = copy.deepcopy(model)
+
+    run_model(model, inputs, False)
+    ret2 = run_model(model_copy, inputs, True)
+    
+    # Make sure param hook has only be fired once in case of parameter sharing
+    assert ret2 == len(list(model.parameters()))
+
+    for p, p_copy in zip(model.parameters(), model_copy.parameters()):
+        assert allclose(p.grad, p_copy.grad), f"{p.grad} vs {p_copy.grad}"
+
+if __name__ == '__main__':
+    test_base_param_hook()

--- a/tests/test_engine/test_engine/test_param_hook.py
+++ b/tests/test_engine/test_engine/test_param_hook.py
@@ -59,8 +59,8 @@ def test_base_param_hook():
 
             hookwrapper = HooKWrapper()
             param_list = [p for p in model.parameters()]
-            BaseParamHook(param_list, hookwrapper.wrapper_func())
-
+            hook_mgr = BaseParamHook(param_list)
+            hook_mgr.register_backward_hooks(hookwrapper.wrapper_func())
         
         model.zero_grad(set_to_none=True)
 

--- a/tests/test_engine/test_engine/test_param_hook.py
+++ b/tests/test_engine/test_engine/test_param_hook.py
@@ -51,7 +51,7 @@ def test_base_param_hook():
                     self.hook_triggered_times = 0
 
                 def wrapper_func(self):
-                    def hook(grad) -> torch.Tensor or None:
+                    def hook(param, grad) -> torch.Tensor or None:
                         self.hook_triggered_times += 1
                         return grad
                     return hook

--- a/tests/test_engine/test_engine/test_param_hook.py
+++ b/tests/test_engine/test_engine/test_param_hook.py
@@ -1,10 +1,9 @@
 import pytest
-from colossalai.engine.paramhooks import BaseParamHook
+from colossalai.engine.paramhooks import BaseParamHookMgr
 from torch import nn
 import torch
 import torch.nn.functional as F
 import copy
-import functools
 
 class SubNet(nn.Module):
     def __init__(self, out_features) -> None:
@@ -58,7 +57,7 @@ def test_base_param_hook():
 
             hookwrapper = HooKWrapper()
             param_list = [p for p in model.parameters()]
-            hook_mgr = BaseParamHook(param_list)
+            hook_mgr = BaseParamHookMgr(param_list)
             hook_mgr.register_backward_hooks(hookwrapper.wrapper_func())
         
         model.zero_grad(set_to_none=True)


### PR DESCRIPTION
Extract hook logic to common utils.
Provides a mechanism to register hooks to params so that users don't need to know how to use hooks (which requires reading a lot of documentation to gain knowledge).
double check with @ver217 , that the backward hook registered on a parameter can only be fired once during BWD.