### PR TITLE
primary memory tracer

### DIFF
--- a/colossalai/amp/naive_amp/naive_amp.py
+++ b/colossalai/amp/naive_amp/naive_amp.py
@@ -3,12 +3,15 @@
 
 import torch
 import torch.nn as nn
+import torch.distributed as dist
 from torch import Tensor
-from typing import Union, List, Any, Dict
+from typing import Any
 from torch.optim import Optimizer
-import torch.cuda.amp as torch_amp
-
+from torch.distributed import ReduceOp
+from colossalai.core import global_context as gpc
+from colossalai.context import ParallelMode
 from colossalai.nn.optimizer import ColossalaiOptimizer
+from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 from ._fp16_optimizer import FP16Optimizer
 
 
@@ -43,16 +46,36 @@ class NaiveAMPOptimizer(ColossalaiOptimizer):
 
 
 class NaiveAMPModel(nn.Module):
-    """A wrapper class for model to cast the model into fp16 and 
+    """A wrapper class for model to cast the model into fp16 and
     automatically cast the input and output
     """
 
     def __init__(self,
                  model: nn.Module,
-                 output_to_fp32: bool = True):
+                 output_to_fp32: bool = True,
+                 parallel_mode: ParallelMode = ParallelMode.DATA,
+                 sync_buffer: bool = True):
         super().__init__()
         self.model = model.half()
         self._output_to_fp32 = output_to_fp32
+        self._sync_buf = sync_buffer
+
+        if gpc.is_initialized(parallel_mode) and gpc.get_world_size(parallel_mode) > 1:
+            self._process_group = gpc.get_group(parallel_mode)
+            self._world_size = gpc.get_world_size(parallel_mode)
+        else:
+            self._process_group = None
+            self._world_size = 1
+            self._sync_buf = False
+        self._first_eval_run = False
+
+    @property
+    def sync_buffer(self):
+        return self._sync_buf
+
+    @sync_buffer.setter
+    def sync_buffer(self, state: bool):
+        self._sync_buf = state
 
     def _convert_to_fp16(self, input_: Any):
         if isinstance(input_, Tensor) and input_.dtype == torch.float32:
@@ -64,7 +87,46 @@ class NaiveAMPModel(nn.Module):
             input_ = input_.float()
         return input_
 
+    def _reduce_module_buffer(self):
+        """
+        All-reduce the buffers (e.g. running stats of batch normalization) across
+        data parallel ranks so that all the ranks will produce consistent results
+        when given the same input
+        """
+        buf_list = []
+
+        # find valid buffers
+        for buf in self.model.buffers():
+            if buf is not None:
+                buf_list.append(buf)
+
+        # reduce buffers across data parallel ranks
+        if buf_list:
+            coalesced_buf = _flatten_dense_tensors(buf_list)
+            coalesced_buf.div_(self._world_size)
+            dist.all_reduce(coalesced_buf, op=ReduceOp.SUM, group=self._process_group)
+            unflattened_buf_list = _unflatten_dense_tensors(coalesced_buf, buf_list)
+            for old, new in zip(buf_list, unflattened_buf_list):
+                old.copy_(new)
+
+    def eval(self):
+        self.model.eval()
+
+        # we only sync buffer in the first eval iteration
+        # so that future eval iterations can be done without communication
+        self._first_eval_run = True
+
     def forward(self, *args, **kwargs):
+        # reduce buffers after forward will lead to error
+        # as we cannot change the variables needed for gradient computation after forward
+        # so we sync buffer before forward
+        if (self.training or self._first_eval_run) and self._sync_buf:
+            with torch.no_grad():
+                self._reduce_module_buffer()
+
+            if self._first_eval_run:
+                self._first_eval_run = False
+
         if args:
             args = [self._convert_to_fp16(arg) for arg in args]
         if kwargs:

--- a/colossalai/engine/_base_engine.py
+++ b/colossalai/engine/_base_engine.py
@@ -26,6 +26,8 @@ class Engine:
     :type gradient_handlers: list
     :param clip_grad_norm: The norm of gradient clipping
     :type clip_grad_norm: float, optional
+    :param ophook_list: List of ophook
+    :type ophook_list: list
     :param verbose: whether to display log info
     :type verbose: bool
     """

--- a/colossalai/engine/ophooks/__init__.py
+++ b/colossalai/engine/ophooks/__init__.py
@@ -1,10 +1,13 @@
-from ._base_ophook import BaseOpHook
-from ._memtracer_ophook import MemTracerOpHook
-from ._shard_param_ophook import ShardParamHook
-import torch
 from typing import List
 
-all = ["BaseOpHook", "MemTracerOpHook", "register_ophooks_recursively", "ShardParamHook"]
+import torch
+
+from ._base_ophook import BaseOpHook
+from ._memtracer_ophook import MemTracerOpHook
+from ._shard_grad_ophook import ShardGradHook
+from ._shard_param_ophook import ShardParamHook
+
+all = ["BaseOpHook", "MemTracerOpHook", "register_ophooks_recursively", "ShardParamHook", "ShardGradHook"]
 
 
 # apply torch.autograd.Function that calls a backward_function to tensors in output

--- a/colossalai/engine/ophooks/_memtracer_ophook.py
+++ b/colossalai/engine/ophooks/_memtracer_ophook.py
@@ -5,18 +5,18 @@ from colossalai.registry import OPHOOKS
 from colossalai.logging import get_dist_logger
 from time import sleep, time
 import pickle
+from typing import Union, Optional
 
-
-def get_cuda_memory_used(device):
+def get_cuda_memory_used(device: Optional[torch.device]) -> int:
     """
     Get the free memory info of device.
     Notice that for CPU, this function will return 1/N of the total free memory,
     where N is the world size.
     """
-    ret = torch.cuda.memory_allocated()
+    ret: int = torch.cuda.memory_allocated(device)
     # get the peak memory to report correct data, so reset the counter for the next call
     if hasattr(torch.cuda, "reset_peak_memory_stats"):  # pytorch 1.4+
-        torch.cuda.reset_peak_memory_stats()
+        torch.cuda.reset_peak_memory_stats(device)
     return ret
 
 

--- a/colossalai/engine/ophooks/_memtracer_ophook.py
+++ b/colossalai/engine/ophooks/_memtracer_ophook.py
@@ -1,3 +1,4 @@
+from re import S
 import torch
 from . import BaseOpHook
 from concurrent.futures import ThreadPoolExecutor
@@ -78,18 +79,49 @@ class AsyncMemoryMonitor:
 
 @OPHOOKS.register_module
 class MemTracerOpHook(BaseOpHook):
-    def __init__(self, niter=5):
+    '''
+    Collect GPU memory usage information
+
+    Args: 
+        warmup (int): This parameter indicates how many iterations to truncate
+        before profiling, e.g. set to 5 and the data will start from 6-th iteration
+        refreshrate (int): This parameter decides the frequency of write file.
+        datafile(string): the name of the stats data file
+    Attributes:
+        _logger (colossalai.logging.logger): output log file
+        _curiter (int): current iteration number
+        _count (int): the number of times the data file was written
+        _datafile (string): the name of the stats data file
+    '''
+    def __init__(self, warmup: int = 50, refreshrate: int = 10, datafile: str = "memstats.pkl"):
         super().__init__()
         self.async_mem_monitor = AsyncMemoryMonitor()
-        self._niter = niter
         self._curiter = 0
         self._logger = get_dist_logger()
+        self._count = 0
+        self._warmup = warmup
+        self._refreshrate = refreshrate
+        self._datafile = datafile
 
-    def _isvalid(self, module):
-        return module.training and self._curiter < self._niter
+    def _isvalid(self, module) -> bool:
+        assert isinstance(module, torch.nn.Module)
+        return module.training
 
-    def niter(self):
-        return self._niter
+    @property
+    def refreshrate(self) -> int:
+        return self._refreshrate
+    
+    @property
+    def warmup(self) -> int:
+        return self._warmup
+
+    @property
+    def curiter(self) -> int:
+        return self._curiter
+
+    @property
+    def valid_iter(self) -> int:
+        return self.curiter - self.warmup
 
     def pre_fwd_exec(self, module: torch.nn.Module, *args):
         if self._isvalid(module):
@@ -103,14 +135,12 @@ class MemTracerOpHook(BaseOpHook):
             self._logger.debug(f'FWD POST {module.__class__.__name__}')
 
     def pre_bwd_exec(self, module: torch.nn.Module, input, output):
-        assert isinstance(module, torch.nn.Module)
         if self._isvalid(module):
             self.async_mem_monitor.finish()
             self.async_mem_monitor.start()
             self._logger.debug(f'BWD PRE {module.__class__.__name__}')
 
     def post_bwd_exec(self, module: torch.nn.Module, input):
-        assert isinstance(module, torch.nn.Module)
         if self._isvalid(module):
             self.async_mem_monitor.finish()
             self._logger.debug(f'BWD POST {module.__class__.__name__}')
@@ -120,11 +150,21 @@ class MemTracerOpHook(BaseOpHook):
 
     def post_iter(self):
         self.async_mem_monitor.finish()
-        if self._curiter == self._niter:
-            self._logger.info(
-                f'dump a memory statistics as pickle to ./memstats.pkl')
-            self.save_results("memstats.pkl")
+        # in the warmup stage
+        if self._curiter <= self.warmup:
+            # TODO: record time and adaptively change sampling rate
+            pass
+        else:
+            # every `refreshrate` times, refresh the file
+            if self.valid_iter != 0 and self.valid_iter % self.refreshrate == 0:
+                # output file info
+                self._logger.info(
+                    f'dump a memory statistics as pickle to {self._datafile}')
+                self.save_results(self._datafile)
+                self._count += 1
+                self._logger.debug(f'data file has been refreshed {self._count} times')
+        # finish a iteration
         self._curiter += 1
 
-    def save_results(self, filename):
-        self.async_mem_monitor.save(filename)
+    def save_results(self):
+        self.async_mem_monitor.save(self._datafile)

--- a/colossalai/engine/ophooks/_shard_grad_ophook.py
+++ b/colossalai/engine/ophooks/_shard_grad_ophook.py
@@ -1,0 +1,31 @@
+import torch
+from colossalai.registry import OPHOOKS
+
+from . import BaseOpHook
+
+
+@OPHOOKS.register_module
+class ShardGradHook(BaseOpHook):
+    """
+    A hook to process sharded param before and afther FWD and BWD operator executing.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def pre_fwd_exec(self, module: torch.nn.Module, *args):
+        pass
+
+    def post_fwd_exec(self, module: torch.nn.Module, *args):
+        pass
+
+    def pre_bwd_exec(self, module: torch.nn.Module, input, output):
+        for param in module.parameters():
+            assert hasattr(param, '_sharded_grad')
+            param._sharded_grad.setup()
+
+    def post_bwd_exec(self, module: torch.nn.Module, input):
+        pass
+
+    def post_iter(self):
+        pass

--- a/colossalai/utils/timer.py
+++ b/colossalai/utils/timer.py
@@ -19,6 +19,11 @@ class Timer:
     def has_history(self):
         return len(self._history) != 0
 
+    @property
+    def current_time(self) -> float:
+        synchronize()
+        return time.time()
+
     def start(self):
         """Fisrtly synchronize cuda, reset the clock and then start the timer.
         """
@@ -26,6 +31,11 @@ class Timer:
         synchronize()
         self._start_time = time.time()
         self._started = True
+
+    def lap(self):
+        """lap time and return elapsed time
+        """
+        return self.current_time - self._start_time
 
     def stop(self, keep_in_history: bool = False):
         """Stop the timer and record the start-stop time interval.

--- a/colossalai/zero/shard_param/shard_param.py
+++ b/colossalai/zero/shard_param/shard_param.py
@@ -1,25 +1,28 @@
 from enum import Enum
-from optparse import Option
 import torch
 from colossalai.zero.sharded_model._zero3_utils import get_shard
 from colossalai.context.parallel_mode import ParallelMode
 from colossalai.core import global_context as gpc
 import torch.distributed as dist
 
+
 class TensorType(Enum):
     GRAD = 1
     DATA = 2
+
 
 class ShardParam(object):
     r"""
     A wrapper to torch.nn.Parameter. Shard a param
     on different processes.
     """
-    def __init__(self,
-            param: torch.nn.Parameter,
-            tensor_type: TensorType = TensorType.DATA,
-            process_group = None,
-        ) -> None:
+
+    def __init__(
+        self,
+        param: torch.nn.Parameter,
+        tensor_type: TensorType = TensorType.DATA,
+        process_group=None,
+    ) -> None:
         self.process_group = process_group or gpc.get_group(ParallelMode.DATA)
         self.world_size = dist.get_world_size(self.process_group)
         self.local_rank = dist.get_rank(self.process_group)
@@ -27,27 +30,27 @@ class ShardParam(object):
         self._payload_numel = None
         self._origin_shape = param.shape
         self._origin_numel = param.numel()
-        self.is_shared = False
-    
-    def payload(self, target_device : torch.device):
+        self.is_sharded = False
+
+    def payload(self, target_device: torch.device):
         return self._param_payload.to(target_device)
 
     def shard(self):
         r"""
         Distributed the payload of param to all processes.
         """
-        if self.is_shared:
+        if self.is_sharded:
             return
         self._param_payload, _ = get_shard(self._param_payload, self.local_rank, self.world_size)
-        self.is_shared = True
-    
+        self.is_sharded = True
+
     def gather(self):
         r"""
         Collect the payload of param from different processes to process of local rank.
         """
-        if not self.is_shared:
+        if not self.is_sharded:
             return
-        
+
         buffer_list = []
         payload_numel = self._param_payload.numel()
         for i in range(self.world_size):
@@ -55,9 +58,10 @@ class ShardParam(object):
                 buffer_list.append(self._param_payload.cuda())
             else:
                 buffer_list.append(torch.zeros(payload_numel).cuda())
-        
-        torch.distributed.all_gather(buffer_list, buffer_list[self.local_rank], group=self.process_group, async_op=False)
-        print(buffer_list)
-        self._param_payload = torch.narrow(torch.cat(buffer_list), 0, 0, self._origin_numel).view(self._origin_shape)
-        self.is_shared = False
 
+        torch.distributed.all_gather(buffer_list,
+                                     buffer_list[self.local_rank],
+                                     group=self.process_group,
+                                     async_op=False)
+        self._param_payload = torch.narrow(torch.cat(buffer_list), 0, 0, self._origin_numel).view(self._origin_shape)
+        self.is_sharded = False

--- a/colossalai/zero/sharded_model/reduce_scatter.py
+++ b/colossalai/zero/sharded_model/reduce_scatter.py
@@ -190,10 +190,6 @@ class ReduceScatterBucketer:
         return int(bucket_size // num_shards)
 
     def _get_bucket(self, tensor: Tensor, group: ProcessGroup) -> Bucket:
-        # TODO (Min): the `group` used here in the key is the object hash, not the content
-        #     hash. That means if FSDP instances are initialized with different process groups,
-        #     even when the group members are in fact the same, we end up creating different
-        #     buckets here.
         key = (tensor.dtype, tensor.device, group)
         if key not in self.buckets:
             # buckets are divided into world_size pieces, bucket.data shaped (world_size, shard_size)

--- a/colossalai/zero/sharded_model/sharded_grad.py
+++ b/colossalai/zero/sharded_model/sharded_grad.py
@@ -1,0 +1,85 @@
+from typing import Optional
+
+import torch
+import torch.nn as nn
+from torch.nn.parameter import Parameter
+
+
+class ShardedGradient:
+    def __init__(self,
+                 param: Parameter,
+                 sharded_module: nn.Module,
+                 offload_config: Optional[dict] = None
+                 ) -> None:
+        assert hasattr(
+            param, 'ca_attr') and param.ca_attr.is_sharded, 'ShardedGradient can only be initialized with sharded parameter'
+
+        self.param = param
+        self.sharded_module = sharded_module
+        self.offload_config = offload_config
+
+        self._cpu_offload = offload_config.get('device', None) == 'cpu' if offload_config else False
+
+        # _gpu_grad is either sharded or not
+        # all saved grads are fp32
+        self._gpu_grad: Optional[torch.Tensor] = None
+        self._cpu_grad: Optional[torch.Tensor] = None
+
+        if self._cpu_offload:
+            # this buffer will be held and reused every iteration
+            self._cpu_grad = torch.zeros(param.ca_attr.payload('cpu'), dtype=torch.float).pin_memory()
+
+    @torch.no_grad()
+    def setup(self) -> None:
+        """This function will be called pre-backward. Save the local accumulated gradient to _gpu_grad.
+        When no_sync() is enable (_require_backward_grad_sync=False), the grad is accumulated locally in param.grad
+
+        :raises AssertionError: Raise if grad shape is wrong
+        """
+        if self.sharded_module._require_backward_grad_sync and self.param.grad is not None:
+            if self.param.grad.device != self.param.data.device:
+                # TODO: offload?
+                raise RuntimeError(
+                    'grad and param are on different device, grad {self.param.grad.device} vs. param {self.param.data.device}')
+            else:
+                self._gpu_grad = self.param.grad.data
+            self.param.grad = None
+
+    def reduce_scatter_callback(self, reduced_grad: torch.Tensor) -> None:
+        """This function will be called in post-backward hook, so we cannot modify param.grad directly
+
+        :param reduced_grad: the reduced grad
+        :type reduced_grad: torch.Tensor
+        """
+        # Make sure we store fp32 grad
+        if torch.is_floating_point(reduced_grad) and reduced_grad.dtype != torch.float:
+            reduced_grad.data = reduced_grad.data.to(torch.float)
+
+        if self._gpu_grad is None:
+            self._gpu_grad = reduced_grad.data
+        else:
+            self._gpu_grad += reduced_grad.data
+
+        # Optionally move gradients to CPU, typically used if one is running the optimizer on the CPU. Once the full
+        # backwards pass completes, we will set `.grad` to the CPU copy.
+        if self._cpu_offload:
+            self._cpu_grad.copy_(self._gpu_grad.data, non_blocking=True)
+            # Don't let this memory get reused until after the transfer.
+            self._gpu_grad.data.record_stream(torch.cuda.current_stream())
+
+    @torch.no_grad()
+    def write_back(self) -> None:
+        """This function will be called in final backward hook
+        """
+        if self._cpu_grad is not None:
+            assert self.param.device == torch.device(
+                'cpu'), f'Incorrect param device, expected CPU, got {self.param.device}'
+            self.param.grad.data = self._cpu_grad
+        elif self._gpu_grad is not None:
+            assert self.param.device == self._gpu_grad.device, f'Incorrect _gpu_grad device, param on {self.param.device} but _gpu_grad on {self._gpu_grad.device}'
+            self.param.grad.data = self._gpu_grad
+        else:
+            raise RuntimeError('No grad to write back')
+        # If using CPU offload, _cpu_grad will store the CPU tensor of _gpu_grad
+        # They should be released here
+        self._gpu_grad = None

--- a/colossalai/zero/sharded_model/sharded_model_v2.py
+++ b/colossalai/zero/sharded_model/sharded_model_v2.py
@@ -1,31 +1,37 @@
 
-import contextlib
-import copy
 import functools
-import os
-import traceback
-from collections import OrderedDict
-from enum import Enum, auto
-from typing import (Any, Callable, Dict, Generator, List, NamedTuple, Optional,
-                    Set, Union)
+from typing import Any, Optional
 
 import torch
 import torch.distributed as dist
 import torch.nn as nn
 from colossalai.context.parallel_mode import ParallelMode
 from colossalai.core import global_context as gpc
+from colossalai.engine.ophooks import (ShardGradHook, ShardParamHook,
+                                       register_ophooks_recursively)
+from colossalai.engine.paramhooks import BaseParamHookMgr
 from colossalai.logging import get_dist_logger
-from colossalai.utils import get_current_device
-from torch.distributed import ProcessGroup
-from colossalai.engine.ophooks import register_ophooks_recursively, BaseOpHook, ShardParamHook
 from colossalai.zero.shard_param import ShardParam
+from colossalai.zero.sharded_model.reduce_scatter import ReduceScatterBucketer
+from colossalai.zero.sharded_model.sharded_grad import ShardedGradient
+from torch.distributed import ProcessGroup
+from torch.nn.parameter import Parameter
+
+from ._zero3_utils import chunk_and_pad, get_gradient_predivide_factor
+
 
 class ShardedModelV2(nn.Module):
     def __init__(self,
                  module: nn.Module,
                  process_group: Optional[ProcessGroup] = None,
-                 reduce_scatter_process_group: Optional[ProcessGroup] = None
-    ):
+                 reduce_scatter_process_group: Optional[ProcessGroup] = None,
+                 reduce_scatter_bucket_size_mb: int = 25,
+                 reshard_after_forward: bool = True,
+                 mixed_precision: bool = False,
+                 fp32_reduce_scatter: bool = False,
+                 offload_config: Optional[dict] = None,
+                 gradient_predivide_factor: Optional[float] = 1.0,
+                 ):
         r"""
         A demo to reconfigure zero1 shared_model.
         Currently do not consider the Optimizer States.
@@ -45,19 +51,111 @@ class ShardedModelV2(nn.Module):
         for _, param in self.module.named_parameters():
             param.ca_attr = ShardParam(param)
             param.ca_attr.shard()
+            param._sharded_grad = ShardedGradient(param, self, offload_config)
 
         # Register hooks
-        register_ophooks_recursively(self.module, [ShardParamHook()])
+        register_ophooks_recursively(self.module, [ShardParamHook(), ShardGradHook()])
+        self.param_hook_mgr = BaseParamHookMgr(list(self.module.parameters()))
+        self.param_hook_mgr.register_backward_hooks(self._grad_post_backward_hook)
+
+        self.reshard_after_forward = reshard_after_forward
+        self.mixed_precision = mixed_precision
+        self.fp32_reduce_scatter = fp32_reduce_scatter
+        self._cpu_offload: bool = offload_config.get('device', None) == 'cpu' if offload_config else False
+        # We find if gradient_predivide_factor != 1.0, there may be wrong precision problem
+        # So we use 1.0 as the default gradient_predivide_factor
+        # However, if you set gradient_predivide_factor to None, we will set gradient_predivide_factor to a value >= 1.0 automatically
+        self.gradient_predivide_factor: float = gradient_predivide_factor if gradient_predivide_factor is not None else \
+            get_gradient_predivide_factor(self.world_size)
+        self.gradient_postdivide_factor: float = self.world_size / self.gradient_predivide_factor
+
+        self.comm_stream: torch.cuda.Stream = torch.cuda.Stream()
+        self.reducer = ReduceScatterBucketer(reduce_scatter_bucket_size_mb)
+        self._require_backward_grad_sync: bool = True
 
     def forward(self, *args: Any, **kwargs: Any) -> torch.Tensor:
         outputs = self.module(*args, **kwargs)
         return outputs
 
-
     def backward(self, loss):
-        if self.loss_scaler:
-            self.loss_scaler.backward(loss)
-        else:
-            loss.backward()
-    
-    
+        loss.backward()
+        self._final_backward_hook()
+
+    @torch.no_grad()
+    def _final_backward_hook(self) -> None:
+        if self._require_backward_grad_sync:
+            # Flush any unreduced buckets in the post_backward stream.
+            with torch.cuda.stream(self.comm_stream):
+                self.reducer.flush()
+            torch.cuda.current_stream().wait_stream(self.comm_stream)
+            if self._cpu_offload:
+                # Wait for the non-blocking GPU -> CPU grad transfers to finish.
+                torch.cuda.current_stream().synchronize()
+        self.reducer.free()
+        for p in self.module.parameters():
+            if not p.requires_grad:
+                continue
+            # Leave the gradient accumulation state as-is if not synchronizing this pass. This ensures p.grad
+            # remains the unsharded gradient accumulated from prior no-sync passes, and _saved_grad_shard
+            # remains the sharded gradient from the last synchronized pass. This also allows interleaved no-sync and
+            # sync passes, if desired.
+            if not self._require_backward_grad_sync:
+                continue
+            p._sharded_grad.write_back()
+
+    @torch.no_grad()
+    def _grad_post_backward_hook(self, param: Parameter, grad: torch.Tensor) -> Optional[torch.Tensor]:
+        """
+        At the start of :func:`_grad_post_backward_hook`, ``param.grad`` contains the
+        full gradient for the local batch. The reduce-scatter op will save a single shard of the summed gradient across all
+        GPUs to param._sharded_grad. This shard will align with the current GPU rank. For example::
+
+            before reduce_scatter:
+                param.grad (GPU #0): [1, 2, 3, 4]
+                param.grad (GPU #1): [5, 6, 7, 8]
+
+            after reduce_scatter:
+                param.grad (GPU #0): [6, 8]    # 1+5, 2+6
+                param.grad (GPU #1): [10, 12]  # 3+7, 4+8
+
+        The local GPU's ``optim.step`` is responsible for updating a single
+        shard of params, also corresponding to the current GPU's rank. This
+        alignment is created by `param._sharded_grad`, which ensures that
+        the local optimizer only sees the relevant parameter shard.
+        """
+        if grad is None:
+            return
+        assert not grad.requires_grad, 'ShardedModel only works with gradients that don\'t require gradients'
+        if not self._require_backward_grad_sync:
+            return
+        self.comm_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(self.comm_stream):
+            new_grad = grad.clone()
+            if self.mixed_precision and self.fp32_reduce_scatter:
+                new_grad.data = new_grad.data.to(param.dtype)
+            if self.gradient_predivide_factor > 1.0:
+                # Average grad by world_size for consistency with PyTorch DDP.
+                new_grad.data.div_(self.gradient_predivide_factor)
+            orig_grad_data = new_grad.data
+            if self.world_size > 1:
+                grad_chunks = chunk_and_pad(orig_grad_data, self.reduce_scatter_process_group.size())
+                self.reducer.reduce_scatter_async(
+                    grad_chunks, group=self.reduce_scatter_process_group, callback_fn=functools.partial(self._reduce_scatter_callback, param))
+            else:
+                self._reduce_scatter_callback(param, new_grad)
+            orig_grad_data.record_stream(self.comm_stream)
+
+    def _reduce_scatter_callback(self, param: Parameter, reduced_grad: torch.Tensor) -> None:
+        if self.gradient_postdivide_factor > 1:
+            # Average grad by world_size for consistency with PyTorch DDP.
+            reduced_grad.data.div_(self.gradient_postdivide_factor)
+        # Cast grad to param's dtype (typically FP32). Note: we do this
+        # before the cpu offload step so that this entire hook remains
+        # non-blocking. The downside is a bit more D2H transfer in that case.
+        if self.mixed_precision:
+            orig_param_grad_data = reduced_grad.data
+            reduced_grad.data = reduced_grad.data.to(dtype=param.ca_attr.origin_dtype)
+            # Don't let this memory get reused until after the transfer.
+            orig_param_grad_data.record_stream(torch.cuda.current_stream())
+
+        param._sharded_grad.reduce_scatter_callback(reduced_grad)

--- a/tests/test_config/test_load_config.py
+++ b/tests/test_config/test_load_config.py
@@ -22,6 +22,7 @@ def test_load_config():
 
 @pytest.mark.cpu
 def test_load_ophooks():
-    dict = {'type': 'MemTracerOpHook', 'niter': 2}
+    dict = {'type': 'MemTracerOpHook', 'warmup': 10, 'refreshrate': 20}
     ophook = build_ophooks(dict)
-    assert ophook.niter() == 2
+    assert ophook.refreshrate == 20
+    assert ophook.warmup == 10

--- a/tests/test_zero_data_parallel/test_shard_model_v2.py
+++ b/tests/test_zero_data_parallel/test_shard_model_v2.py
@@ -3,19 +3,18 @@
 
 import copy
 from functools import partial
-from operator import mod
-from pyexpat import model
 
 import colossalai
 import pytest
 import torch
+import torch.distributed as dist
 import torch.multiprocessing as mp
-from colossalai.logging import disable_existing_loggers
+from colossalai.context.parallel_mode import ParallelMode
+from colossalai.core import global_context as gpc
 from colossalai.utils import free_port
 from colossalai.zero.sharded_model import ShardedModelV2
-from colossalai.core import global_context as gpc
-from colossalai.context.parallel_mode import ParallelMode
-from tests.test_zero_data_parallel.common import Net, CONFIG, check_grads
+
+from common import CONFIG, Net, check_grads, check_grads_padding
 
 
 def run_fwd_bwd(model, x, enable_autocast=False):
@@ -24,8 +23,11 @@ def run_fwd_bwd(model, x, enable_autocast=False):
         y = model(x)
         loss = y.sum()
     loss = loss.float()
-    loss.backward()
-    
+    if isinstance(model, ShardedModelV2):
+        model.backward(loss)
+    else:
+        loss.backward()
+
 
 def run_dist(rank, world_size, port):
     colossalai.launch(config=CONFIG,
@@ -34,7 +36,7 @@ def run_dist(rank, world_size, port):
                       host='localhost',
                       port=port,
                       backend='nccl')
-    
+
     model = Net(checkpoint=True).cuda()
     zero_model = copy.deepcopy(model)
     zero_model = ShardedModelV2(zero_model, process_group=gpc.get_group(ParallelMode.DATA))
@@ -43,7 +45,10 @@ def run_dist(rank, world_size, port):
         x = torch.rand(2, 5).cuda()
         run_fwd_bwd(zero_model, x, False)
         run_fwd_bwd(model, x, False)
-        check_grads(model, zero_model)
+        if dist.get_world_size() > 1:
+            check_grads_padding(model, zero_model)
+        else:
+            check_grads(model, zero_model)
 
 
 @pytest.mark.dist

--- a/tests/test_zero_data_parallel/test_sharded_optim.py
+++ b/tests/test_zero_data_parallel/test_sharded_optim.py
@@ -1,0 +1,178 @@
+import torch
+import colossalai
+import copy
+import pytest
+import torch.multiprocessing as mp
+import torch.nn as nn
+from colossalai.zero import ShardedOptimizer
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+from colossalai.utils import free_port
+from functools import partial
+
+
+def check_equal(a, b):
+    """
+    This function checks if two tensors are equal within tolerance
+    """
+    assert torch.allclose(a.float(), b.float(), rtol=1e-4, atol=1e-3), f'a = {a}, b = {b}'
+
+
+def check_completely_equal(a, b):
+    """
+    This function checks if two tensors are completely equal
+    """
+    assert torch.all(a == b), f'a = {a}, b = {b}'
+
+
+def check_sharded_param_consistency():
+    """
+    In this test, we want to test whether zero stage 1 and 2
+    deliver the same numerical results despite different communication
+    pattern
+
+    we use these prefixes to differentiate the zero stage
+    oss: partition optimizer states
+    pg: partition gradients and optimizer states
+
+    """
+
+    # create layers
+    oss_linear1 = nn.Linear(128, 256)
+    oss_linear2 = nn.Linear(256, 512)
+
+    # create model
+    oss_model = nn.Sequential(oss_linear1, oss_linear2)
+    pg_model = copy.deepcopy(oss_model)
+
+    oss_model = oss_model.cuda().half()
+    pg_model = pg_model.cuda().half()
+
+    # create optimizer
+    oss_optimizer = torch.optim.Adam(oss_model.parameters(), lr=0.001)
+    pg_optimizer = torch.optim.Adam(pg_model.parameters(), lr=0.001)
+    oss_optimizer = ShardedOptimizer(oss_optimizer, overlap_communication=True, initial_scale=1, clip_grad_norm=0.0)
+    pg_optimizer = ShardedOptimizer(pg_optimizer,
+                                    overlap_communication=True,
+                                    partition_grad=True,
+                                    initial_scale=1,
+                                    clip_grad_norm=0.0)
+
+    # create
+    input_data = torch.rand(32, 128).cuda().half()
+
+    # forward
+    oss_output = oss_model(input_data)
+    pg_output = pg_model(input_data)
+    check_completely_equal(oss_output, pg_output)
+
+    # backward
+    oss_optimizer.backward(oss_output.mean().float())
+    pg_optimizer.backward(pg_output.mean().float())
+
+    # check grad
+    # as this param is small, the backward reduction
+    # will not be fired
+    oss_linear1_grad = oss_model[0].weight.grad
+    oss_linear2_grad = oss_model[1].weight.grad
+    pg_linear1_grad = pg_model[0].weight.grad
+    pg_linear2_grad = pg_model[1].weight.grad
+    check_completely_equal(oss_linear1_grad, pg_linear1_grad)
+    check_completely_equal(oss_linear2_grad, pg_linear2_grad)
+
+    # step
+    oss_optimizer.sync_grad()
+    pg_optimizer.sync_grad()
+
+    # step
+    oss_optimizer.step()
+    pg_optimizer.step()
+
+    # check updated param
+    check_completely_equal(oss_model[0].weight, pg_model[0].weight)
+    check_completely_equal(oss_model[1].weight, pg_model[1].weight)
+
+
+def check_sharded_optim_against_torch_ddp():
+    """
+    In this test, two pairs of model and optimizers are created.
+    1. zero: use sharded optimizer and fp16 parameters
+    2. torch: use torch DDP and fp32 parameters
+
+    We feed these two sets of models with the same input and check if the
+    differences in model output and updated parameters are within tolerance.
+    """
+
+    # create layer
+    zero_linear1 = nn.Linear(128, 256)
+    zero_linear2 = nn.Linear(256, 512)
+
+    # create model
+    zero_model = nn.Sequential(zero_linear1, zero_linear2)
+    torch_model = copy.deepcopy(zero_model)
+
+    zero_model = zero_model.cuda().half()
+    torch_model = DDP(torch_model.cuda())
+
+    # create optimizer
+    zero_optimizer = torch.optim.Adam(zero_model.parameters(), lr=0.001)
+
+    # we only test stage 1 here
+    # in `check_sharded_param_consistency.py`, we will test whether
+    # level 1 and 2 will produce exactly the same results
+    zero_optimizer = ShardedOptimizer(zero_optimizer, overlap_communication=True, initial_scale=1, clip_grad_norm=0.0)
+
+    torch_optimizer = torch.optim.Adam(torch_model.parameters(), lr=0.001)
+
+    # create
+    input_data = torch.rand(32, 128).cuda()
+
+    # zero-dp forward
+    zero_output = zero_model(input_data.half())
+
+    # torch-ddp forward
+    torch_output = torch_model(input_data)
+    check_equal(zero_output, torch_output)
+
+    # zero-dp backward
+    zero_optimizer.backward(zero_output.mean().float())
+
+    # torch-ddp backward
+    torch_output.mean().backward()
+
+    # check grad
+    zero_linear1_grad = zero_model[0].weight.grad
+    zero_linear2_grad = zero_model[1].weight.grad
+    torch_linear1_grad = torch_model.module[0].weight.grad
+    torch_linear2_grad = torch_model.module[1].weight.grad
+    check_equal(zero_linear1_grad, torch_linear1_grad)
+    check_equal(zero_linear2_grad, torch_linear2_grad)
+
+    # zero-dp step
+    zero_optimizer.sync_grad()
+    zero_optimizer.step()
+
+    # torch ddp step
+    torch_optimizer.step()
+
+    # check updated param
+    check_equal(zero_model[0].weight, torch_model.module[0].weight)
+    check_equal(zero_model[1].weight, torch_model.module[1].weight)
+
+
+def run_dist(rank, world_size, port):
+    colossalai.launch(config=dict(), rank=rank, world_size=world_size, port=port, host='localhost')
+
+    check_sharded_optim_against_torch_ddp()
+    check_sharded_param_consistency()
+
+
+@pytest.mark.dist
+def test_sharded_optim():
+    world_size = 2
+    run_func = partial(run_dist, world_size=world_size, port=free_port())
+    mp.spawn(run_func, nprocs=world_size)
+
+
+if __name__ == '__main__':
+    test_sharded_optim()

--- a/tests/test_zero_data_parallel/test_sharded_optim_with_sync_bn.py
+++ b/tests/test_zero_data_parallel/test_sharded_optim_with_sync_bn.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
+from functools import partial
+
+import colossalai
+import pytest
+import torch
+import torch.multiprocessing as mp
+from colossalai.utils import free_port
+from colossalai.core import global_context as gpc
+from colossalai.context.parallel_mode import ParallelMode
+from torchvision.models import resnet50
+import torch.distributed as dist
+
+
+def run_dist(rank, world_size, port):
+    # need to configure cudnn deterministic so that
+    # randomness of convolution layers will be disabled
+    colossalai.launch(config=dict(zero=dict(level=2, partition_grad=True),
+                                  cudnn_determinstic=True,
+                                  cudnn_benchmark=False),
+                      rank=rank,
+                      world_size=world_size,
+                      host='localhost',
+                      port=port,
+                      backend='nccl')
+
+    model = resnet50()
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
+    criterion = torch.nn.CrossEntropyLoss()
+
+    engine, *args = colossalai.initialize(model, optimizer, criterion)
+
+    # train for dummy iterations
+    engine.train()
+    for _ in range(2):
+        data = torch.rand(4, 3, 128, 128).cuda().half()
+        label = torch.randint(0, 10, size=(4,)).cuda()
+        engine.zero_grad()
+        out = engine(data)
+        loss = engine.criterion(out, label)
+        engine.backward(loss)
+        engine.step()
+
+    # test
+    # need to make sure the batch norm stats are synchronized
+    # so that given the same input, the model will produce the same
+    # output on different ranks
+    engine.eval()
+    data = torch.rand(4, 3, 128, 128).cuda().half()
+    dist.broadcast(data, src=0, group=gpc.get_group(ParallelMode.DATA))
+
+    # predict
+    out = engine(data)
+
+    # test if results are equal
+    tensor_list = [torch.empty_like(out) for _ in range(world_size - 1)]
+    tensor_list.insert(rank, out)
+    dist.all_gather(tensor_list=tensor_list, tensor=out, group=gpc.get_group(ParallelMode.DATA))
+
+    assert torch.all(tensor_list[0] == tensor_list[1]), \
+        'expected the output from different ranks to be the same, but got different values'
+
+
+@pytest.mark.dist
+def test_sharded_optim_with_sync_bn():
+    """
+    This test is to make sure that buffers are synchronized between ranks
+    when using ZeRO. An example of module buffer is the running stats of
+    BatchNormalization layer, i.e. mean and var.
+
+    If the buffers are not synchronized, the model will produce different
+    output even though the input and parameters are the same. This is not
+    wanted if we are doing predictions.
+
+    """
+    world_size = 2
+    run_func = partial(run_dist, world_size=world_size, port=free_port())
+    mp.spawn(run_func, nprocs=world_size)
+
+
+if __name__ == '__main__':
+    test_sharded_optim_with_sync_bn()


### PR DESCRIPTION
This primary memory tracer is used to collect memory usage during each iteration, and it works well on the standalone node. Adaptive sampling and timer synchronization have already been implemented but the unit test is not yet finished. There are some other design problems:

1. Shall we provide the `warmup` parameter? In most cases, only several iterations will be affected by non-training factors. 
2. I believe users are supposed to show the results based on iterations or time intervals, e.g. show the memory usage between the 10-th and 15-th iterations.