### PR TITLE
[zero] fix grad shape error for ShardededModelv2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     container:
       image: nvcr.io/nvidia/pytorch:21.07-py3
       options: --gpus all --rm --ipc=host -v /data/scratch/cifar-10:/data/scratch/cifar-10
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - name: Setup Environment
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     container:
       image: nvcr.io/nvidia/pytorch:21.07-py3
       options: --gpus all --rm --ipc=host -v /data/scratch/cifar-10:/data/scratch/cifar-10
-    timeout-minutes: 25
+    timeout-minutes: 40
     steps:
       - name: Setup Environment
         run: |


### PR DESCRIPTION
Current code can handle ZeRO-3. However, if we don't shard param (ZeRO-2), current code will throw errors, because of wrong grad shape. I fix grad shape, so that we can handle both ZeRO-3 and ZeRO-2.