### PR TITLE
[zero] use double buffers to handle grad

### DIFF
--- a/colossalai/engine/ophooks/zero_hook.py
+++ b/colossalai/engine/ophooks/zero_hook.py
@@ -1,12 +1,14 @@
+from typing import Optional
+
 import torch
 from colossalai.registry import OPHOOKS
 from colossalai.utils import get_current_device
+from colossalai.utils.memory_tracer.memstats_collector import MemStatsCollector
+from colossalai.utils.memory_tracer.model_data_memtracer import \
+    GLOBAL_MODEL_DATA_TRACER
 from colossalai.zero.shard_utils import BaseShardStrategy
 
 from ._base_ophook import BaseOpHook
-from colossalai.utils.memory_tracer.memstats_collector import MemStatsCollector
-from colossalai.utils.memory_tracer.model_data_memtracer import GLOBAL_MODEL_DATA_TRACER
-from typing import Optional
 
 
 @OPHOOKS.register_module
@@ -62,8 +64,8 @@ class ZeroHook(BaseOpHook):
             if param.grad is not None:
                 if param.col_attr.bwd_count == 0:
                     # We haven't stored local accumulated grad yet
-                    assert param.col_attr.grad is None
-                    param.col_attr.grad = param.grad.data
+                    assert param.col_attr.fp32_grad is None
+                    param.col_attr.fp32_grad = param.grad.data
                     param.grad = None
                 else:
                     # We have stored local accumulated grad

--- a/colossalai/zero/init_ctx/init_context.py
+++ b/colossalai/zero/init_ctx/init_context.py
@@ -1,9 +1,10 @@
 import functools
 
 import torch
+from colossalai.utils.memory_tracer.model_data_memtracer import \
+    GLOBAL_MODEL_DATA_TRACER
 from colossalai.zero.shard_utils import BaseShardStrategy
 from colossalai.zero.sharded_param import ShardedParamV2
-from colossalai.utils.memory_tracer.model_data_memtracer import GLOBAL_MODEL_DATA_TRACER
 
 # Inserts _post_init_method at the end of init method
 
@@ -154,6 +155,6 @@ class ZeroInitContext(InsertPostInitMethodToModuleSubClasses):
             if self.shard_param:
                 self.shard_strategy.shard(tensor_list=[param.col_attr._data_sharded_tensor])
                 GLOBAL_MODEL_DATA_TRACER.add_tensor(param.col_attr._data_sharded_tensor.payload)
-            if param.col_attr.grad and self.shard_grad:
-                self.shard_strategy.shard(tensor_list=[param.col_attr._grad_sharded_tensor])
-                GLOBAL_MODEL_DATA_TRACER.add_tensor(param.col_attr._grad_sharded_tensor.payload)
+            # if param.col_attr.grad and self.shard_grad:
+            #     self.shard_strategy.shard(tensor_list=[param.col_attr._grad_sharded_tensor])
+            #     GLOBAL_MODEL_DATA_TRACER.add_tensor(param.col_attr._grad_sharded_tensor.payload)

--- a/colossalai/zero/sharded_model/sharded_model_v2.py
+++ b/colossalai/zero/sharded_model/sharded_model_v2.py
@@ -218,6 +218,7 @@ class ShardedModelV2(nn.Module):
             else:
                 self._reduce_scatter_callback(param, new_grad)
             orig_grad_data.record_stream(self.comm_stream)
+        torch.cuda.current_stream().wait_stream(self.comm_stream)
         empty_grad = torch.empty_like(grad)
         free_storage(empty_grad)
         return empty_grad

--- a/colossalai/zero/sharded_param/sharded_param.py
+++ b/colossalai/zero/sharded_param/sharded_param.py
@@ -16,7 +16,8 @@ class ShardedParamV2(object):
                  process_group: Optional[dist.ProcessGroup] = None,
                  rm_torch_payload=False) -> None:
         self._data_sharded_tensor: ShardedTensor = ShardedTensor(param.data, process_group)
-        self._grad_sharded_tensor: Optional[torch.Tensor] = None
+        self.fp16_grad: Optional[torch.Tensor] = None
+        self.fp32_grad: Optional[torch.Tensor] = None
 
         # make sure the shared param is the only owner of payload
         # The param.data maybe used to init the other part of the model.
@@ -38,14 +39,6 @@ class ShardedParamV2(object):
     @property
     def data(self):
         return self._data_sharded_tensor
-
-    @property
-    def grad(self):
-        return self._grad_sharded_tensor
-
-    @grad.setter
-    def grad(self, t: torch.Tensor):
-        self._grad_sharded_tensor = t
 
     @property
     def param_is_sharded(self):


### PR DESCRIPTION
In order to support partial offload, we use double buffers to handle grad (`fp16_grad` and `fp32_grad`). `fp16_grad` is always on GPU, and `fp32_grad` may be partially on GPU and CPU.