### PR TITLE
[DevOps] remove unneeded dependency in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
           pip install -U pip setuptools wheel --user
           pip install pytest tensorboard transformers
       - uses: actions/checkout@v2
+        with:
+          ssh-key: ${{ secrets.SSH_KEY_FOR_CI }}
       - name: Install Colossal-AI      
         run: |
           pip install -r requirements/requirements.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
           pip install -U pip setuptools wheel --user
-          pip install pytest tensorboard deepspeed apex transformers
+          pip install pytest tensorboard transformers
       - uses: actions/checkout@v2
       - name: Install Colossal-AI      
         run: |


### PR DESCRIPTION
This is part of the efforts to tackle #443  
- Remove `apex` and `deepspeed` from the dependency list in the build workflow so that they are no longer installed on the fly in the CI. `deepspeed` is no longer our dependency and `apex` is built-in in the Nvidia NGC docker.
- configure the checkout action to use ssh to shorten checkout time

