### PR TITLE
add cpu adamW

### DIFF
--- a/colossalai/nn/optimizer/__init__.py
+++ b/colossalai/nn/optimizer/__init__.py
@@ -5,7 +5,8 @@ from .fused_sgd import FusedSGD
 from .lamb import Lamb
 from .lars import Lars
 from .cpu_adam import CPUAdam
+from .cpu_adamw import CPUAdamW
 
 __all__ = [
-    'ColossalaiOptimizer', 'FusedLAMB', 'FusedAdam', 'FusedSGD', 'Lamb', 'Lars', 'CPUAdam'
+    'ColossalaiOptimizer', 'FusedLAMB', 'FusedAdam', 'FusedSGD', 'Lamb', 'Lars', 'CPUAdam', 'CPUAdamW'
 ]


### PR DESCRIPTION
Added cpu AdamW.
Separate the class `CPUAdam` and `CPUAdamW`, users can not defined an adamw by passing a parameter `adamw_mode` when init.