### PR TITLE
[WIP] demonstrate writing parallel op with customized tensors structure

### DIFF
--- a/colossalai/nn/layer/parallel_ops/__init__.py
+++ b/colossalai/nn/layer/parallel_ops/__init__.py
@@ -1,0 +1,1 @@
+from .linear import *

--- a/colossalai/nn/layer/parallel_ops/linear.py
+++ b/colossalai/nn/layer/parallel_ops/linear.py
@@ -9,6 +9,9 @@ from packaging import version
 
 @sharded_op_impl(torch.nn.functional.linear)
 def sharded_linear(types, args, kwargs, pg):
+    """Handles ``__torch_function__`` dispatch for ``torch.nn.functional.linear``.
+    This method computes a sharded linear.
+    """
     rank = dist.get_rank(pg)
     print(f'inside sharded_linear {len(args)}')
     print(f'inside sharded_linear kwargs {kwargs}')
@@ -27,6 +30,8 @@ def sharded_linear(types, args, kwargs, pg):
             bias = bias.payload
 
     print(bias)
+
+    # Add communication logic before and after linear call.
     if isinstance(weight, ShardedTensor):
         return torch.nn.functional.linear(input, weight.payload.t(), bias)
     else:

--- a/colossalai/nn/layer/parallel_ops/linear.py
+++ b/colossalai/nn/layer/parallel_ops/linear.py
@@ -1,0 +1,33 @@
+import torch
+import torch.distributed as dist
+
+from colossalai.nn.layer.parallel_ops.wrapper import sharded_op_impl
+from colossalai.zero.sharded_param.sharded_param import ShardedTensor
+
+from packaging import version
+
+
+@sharded_op_impl(torch.nn.functional.linear)
+def sharded_linear(types, args, kwargs, pg):
+    rank = dist.get_rank(pg)
+    print(f'inside sharded_linear {len(args)}')
+    print(f'inside sharded_linear kwargs {kwargs}')
+    # print(args)
+    input = args[0]
+    weight = args[1]
+
+    if version.parse(torch.__version__) > version.parse("1.11.0"):
+        if len(args) == 3:
+            bias = args[2]
+        else:
+            bias = None
+    else:
+        bias = kwargs.get('bias', None)
+        if isinstance(bias, ShardedTensor):
+            bias = bias.payload
+
+    print(bias)
+    if isinstance(weight, ShardedTensor):
+        return torch.nn.functional.linear(input, weight.payload.t(), bias)
+    else:
+        return torch.nn.functional.linear(input, weight, bias)

--- a/colossalai/nn/layer/parallel_ops/test_linear.py
+++ b/colossalai/nn/layer/parallel_ops/test_linear.py
@@ -1,0 +1,43 @@
+import torch
+from functools import partial
+import torch.multiprocessing as mp
+from colossalai.zero.sharded_param import ShardedTensor
+
+
+def run_dist(rank, world_size, port):
+    import colossalai
+    colossalai.launch(config={}, rank=rank, world_size=world_size, host='localhost', port=port, backend='nccl')
+
+    in_dim = 4
+    out_dim = 5
+
+    fc = torch.nn.Linear(in_dim, out_dim, bias=True)
+
+    sharded_weight = ShardedTensor(torch.randn(in_dim, out_dim, requires_grad=True))
+    bias = torch.randn(out_dim, requires_grad=True)
+    sharded_bias = ShardedTensor(bias)
+
+    # replace the torch nn.Parameters with ShardedTensor
+    delattr(fc, 'weight')
+    setattr(fc, 'weight', sharded_weight)
+    delattr(fc, 'bias')
+    setattr(fc, 'bias', sharded_bias)
+
+    fc.weight.requires_grad = True
+    fc.bias.requires_grad = True
+
+    # torch.nn.functional.linear(torch.randn(1, in_dim), sharded_weight, sharded_bias)
+    out = fc(torch.randn(1, in_dim))
+
+    loss = out.sum()
+    loss.backward()
+
+
+def test_customized_linear(world_size):
+    from colossalai.utils import free_port
+    run_func = partial(run_dist, world_size=world_size, port=free_port())
+    mp.spawn(run_func, nprocs=world_size)
+
+
+if __name__ == '__main__':
+    test_customized_linear(4)

--- a/colossalai/nn/layer/parallel_ops/wrapper.py
+++ b/colossalai/nn/layer/parallel_ops/wrapper.py
@@ -1,0 +1,61 @@
+# The functions used in this file are copied from pytorch
+
+from typing import Dict, Callable
+import functools
+
+# Custom sharded ops
+_SHARDED_OPS: Dict[str, Callable] = {}
+
+
+def _register_sharded_op(op, func):
+    from inspect import signature
+    if len(signature(func).parameters) != 4:
+        raise TypeError(f'Custom sharded op function expects signature: '
+                        f'(types, args, kwargs, process_group), but received '
+                        f'signature: {signature(func)}')
+
+    global _SHARDED_OPS
+    _SHARDED_OPS[op] = func
+
+
+def sharded_op_impl(func):
+    """
+    Provides a way for users to write their own custom sharded operator. This
+    can be used to override existing ShardedTensor operators or write a new
+    one not supported by ShardedTensor. If the operator in question is covered
+    by ``__torch_function__`` dispatch and has a ShardedTensor as any of its
+    parameters, the function provided will be invoked for that operator.
+
+    Example::
+        >>> @custom_sharded_op(torch.nn.functional.linear)
+        >>> def my_custom_sharded_linear(types, args, kwargs, process_group):
+        >>>   ....
+        >>>
+        >>> input = torch.rand(10, 32)
+        >>> weight = sharded_tensor.rand(32, 16)
+        >>> bias = torch.rand(16)
+        >>> # This will call 'my_custom_sharded_linear'
+        >>> torch.nn.functional.linear(input, weight, bias)
+
+    The types, args and kwargs parameters are the same parameters that are
+    passed to ``__torch_function__`` dispatch API
+    (https://pytorch.org/docs/stable/notes/extending.html#extending-torch).
+    There is an additional ``process_group`` parameter which is the
+    process_group used for the ShardedTensor and can be used by
+    implementations for communications within a sharded implementation.
+
+    Args:
+        func(Callable): Torch function for which we want to provide a sharded
+            implementation (ex: torch.nn.functional.linear)
+    """
+
+    def decorator_sharded_func(wrapped_func):
+        _register_sharded_op(func, wrapped_func)
+
+        @functools.wraps(wrapped_func)
+        def wrapper(*args, **kwargs):
+            return wrapped_func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator_sharded_func


### PR DESCRIPTION
With the help of [```__torch_function__```](https://pytorch.org/docs/stable/notes/extending.html), we can follow a new paradigm to develop parallel operators.
In this demo, I showed a way to define a customized Linear Op on ShardedTensor. In this way, users do not need to change its model definition while using our customized Op.
We can add Tensor Parallel/ZeRO logic in the customized Linear Op. Therefore the parameter tensor data structure of TP and ZeRO can be unified.