### PR TITLE
[devops] recover tsinghua pip source due to proxy issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
           pip install -U pip setuptools wheel --user
           pip install pytest tensorboard transformers
       - uses: actions/checkout@v2

--- a/.github/workflows/compatibility_test.yml
+++ b/.github/workflows/compatibility_test.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
           pip install -U pip setuptools wheel --user
           pip install pytest tensorboard deepspeed apex
       - uses: actions/checkout@v2


### PR DESCRIPTION
Using proxy inside a docker container will lead to connection error, so stick to using Tsinghua source.