### PR TITLE
[zero] fix grad offload

### DIFF
--- a/colossalai/zero/sharded_model/sharded_model_v2.py
+++ b/colossalai/zero/sharded_model/sharded_model_v2.py
@@ -11,8 +11,8 @@ from colossalai.engine.ophooks import register_ophooks_recursively
 from colossalai.engine.ophooks.zero_hook import ZeroHook
 from colossalai.engine.paramhooks import BaseParamHookMgr
 from colossalai.logging import get_dist_logger
-from colossalai.utils.memory_utils.utils import colo_model_data_move_to_cpu, colo_cuda_memory_capacity
 from colossalai.utils.memory_tracer.memstats_collector import MemStatsCollector
+from colossalai.utils.memory_utils.utils import (colo_cuda_memory_capacity, colo_model_data_move_to_cpu)
 from colossalai.zero.shard_utils import BaseShardStrategy
 from colossalai.zero.sharded_model.reduce_scatter import ReduceScatterBucketer
 from torch.distributed import ProcessGroup
@@ -27,7 +27,7 @@ class ShardedModelV2(nn.Module):
     A wrapper for the PyTorch module shards the model parameters among multiple GPU memory.
     Only 1/#nproc of parameters, gradients are stored in local CUDA memory, so forward and backward
     passes can be executed with limited CUDA memory budget.
-    
+
     Note that you must use `ShardedModelV2` with `ShardedOptimizerV2`.
 
     Args:
@@ -202,7 +202,12 @@ class ShardedModelV2(nn.Module):
             else:
                 grad = cast_tensor_to_fp32(p.col_attr.fp16_grad)
             if p.col_attr.offload_grad:
-                colo_model_data_move_to_cpu(grad)
+                # When reuse_fp16_shard, we cannot modify payload itself
+                # since this will lead to the wrong device of payload
+                # We have to return a new CPU tensor
+                # FIXME(ver217): we don't monitor grad now, uncomment the below line when monitoring grad
+                # colo_model_data_move_to_cpu(grad)
+                grad = grad.cpu()
             if p.col_attr.fp32_grad is not None:
                 assert not self.reuse_fp16_shard, 'Gradien accumulation is not supported when reuse_fp16_shard=True'
                 p.col_attr.fp32_grad.add_(grad.view_as(p.col_attr.fp32_grad))


### PR DESCRIPTION
When reuse fp16 shard, we cannot modify payload itself, since this will lead to wrong device of payload. We have to return a new CPU tensor.