### PR TITLE
[ci] remove ipc config for rootless docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [self-hosted, gpu]
     container:
       image: frankleeeee/pytorch-cuda:1.10.1-11.3.0
-      options: --gpus all --rm --ipc=host -v /data/scratch/cifar-10:/data/scratch/cifar-10
+      options: --gpus all --rm -v /data/scratch/cifar-10:/data/scratch/cifar-10
     timeout-minutes: 40
     steps:
       - name: Install dependencies

--- a/.github/workflows/compatibility_test.yml
+++ b/.github/workflows/compatibility_test.yml
@@ -41,7 +41,7 @@ jobs:
       matrix: ${{fromJson(needs.matrix_preparation.outputs.matrix)}}
     container:
       image: ${{ matrix.container }}
-      options: --gpus all --rm --ipc=host -v /data/scratch/cifar-10:/data/scratch/cifar-10
+      options: --gpus all --rm -v /data/scratch/cifar-10:/data/scratch/cifar-10
     timeout-minutes: 120
     steps:
       - name: Install dependencies


### PR DESCRIPTION
Fixed #696 by modifying the workflow script for rootless docker. The CI runs have now been executed by `gitact` instead of `root`.

<img width="726" alt="Screenshot 2022-04-08 at 1 58 58 AM" src="https://user-images.githubusercontent.com/31818963/162349381-e5d33dd2-1a15-4278-bcae-4e857f31a1fc.png">

