### PR TITLE
[cli] add missing requirement

### DIFF
--- a/colossalai/cli/__init__.py
+++ b/colossalai/cli/__init__.py
@@ -1,0 +1,3 @@
+from .cli import cli
+
+__all__ = ['cli']

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,3 +7,4 @@ tensorboard
 packaging
 pre-commit
 rich
+click

--- a/setup.py
+++ b/setup.py
@@ -215,7 +215,7 @@ setup(
     install_requires=fetch_requirements('requirements/requirements.txt'),
     entry_points='''
         [console_scripts]
-        colossal=colossalai.cli.cli:cli
+        colossal=colossalai.cli:cli
     ''',
     python_requires='>=3.7',
     classifiers=[


### PR DESCRIPTION
I have added `click` to the requirement list. Meanwhile, the scope of cli module is modified to only expose the `cli` function to the outsider.