### PR TITLE
[cli] fixed a bug in user args and refactored the module structure

### DIFF
--- a/colossalai/cli/cli.py
+++ b/colossalai/cli/cli.py
@@ -1,77 +1,34 @@
 import click
-from colossalai.cli.launcher.run import main as col_launch
+from .launcher import run
 from colossalai.cli.benchmark.utils import BATCH_SIZE, SEQ_LENGTH, HIDDEN_DIM, ITER_TIMES
 from colossalai.cli.benchmark.run import launch as col_benchmark
 
+
 class Arguments():
+
     def __init__(self, arg_dict):
         for k, v in arg_dict.items():
             self.__dict__[k] = v
+
 
 @click.group()
 def cli():
     pass
 
+
 @click.command()
-@click.option("--num_gpus",
-                type=int,
-                default=-1)
-@click.option("--bs",
-                type=int,
-                default=BATCH_SIZE)
-@click.option("--seq_len",
-                type=int,
-                default=SEQ_LENGTH)
-@click.option("--hid_dim",
-                type=int,
-                default=HIDDEN_DIM)
-@click.option("--num_steps",
-                type=int,
-                default=ITER_TIMES)
+@click.option("--num_gpus", type=int, default=-1)
+@click.option("--bs", type=int, default=BATCH_SIZE)
+@click.option("--seq_len", type=int, default=SEQ_LENGTH)
+@click.option("--hid_dim", type=int, default=HIDDEN_DIM)
+@click.option("--num_steps", type=int, default=ITER_TIMES)
 def benchmark(num_gpus, bs, seq_len, hid_dim, num_steps):
     args_dict = locals()
     args = Arguments(args_dict)
     col_benchmark(args)
 
-@click.command()
-@click.option("--hostfile", 
-                type=str,
-                default="")
-@click.option("--include",
-              type=str,
-              default="")
-@click.option("--exclude",
-                type=str,
-                default="")
-@click.option("--num_nodes",
-                type=int,
-                default=-1)
-@click.option("--num_gpus",
-                type=int,
-                default=-1)
-@click.option("--master_port",
-                type=int,
-                default=29500)
-@click.option("--master_addr",
-                type=str,
-                default="127.0.0.1")
-@click.option("--launcher",
-                type=str,
-                default="torch")
-@click.option("--launcher_args",
-                type=str,
-                default="")
-@click.argument("user_script",
-                type=str)
-@click.argument('user_args', nargs=-1)
-def launch(hostfile, num_nodes, num_gpus, include, exclude, master_addr, master_port, 
-           launcher, launcher_args, user_script, user_args):
-    args_dict = locals()
-    args = Arguments(args_dict)
-    args.user_args = list(args.user_args)
-    col_launch(args)
 
-cli.add_command(launch)
+cli.add_command(run)
 cli.add_command(benchmark)
 
 if __name__ == '__main__':

--- a/colossalai/cli/launcher/__init__.py
+++ b/colossalai/cli/launcher/__init__.py
@@ -1,0 +1,70 @@
+import click
+from .run import launch_multi_processes
+from colossalai.context import Config
+
+
+@click.command(help="Launch distributed training on a single node or multiple nodes",
+               context_settings=dict(ignore_unknown_options=True))
+@click.option("-H", "-host", "--host", type=str, default=None, help="the list of machines to launch")
+@click.option("--hostfile",
+              type=str,
+              default=None,
+              help="Hostfile path that defines the device pool available to the job (e.g. worker-name:number of slots)")
+@click.option(
+    "--include",
+    type=str,
+    default=None,
+    help=
+    "Specify computing devices to use during execution. String format is NODE_SPEC@NODE_SPEC where NODE_SPEC=<worker-name>:<list-of-slots>"
+)
+@click.option(
+    "--exclude",
+    type=str,
+    default=None,
+    help=
+    "Specify computing devices to NOT use during execution. Mutually exclusive with --include. Formatting is the same as --include."
+)
+@click.option("--num_nodes", type=int, default=-1, help="Total number of worker nodes to use.")
+@click.option("--nprocs_per_node", type=int, default=-1, help="Number of GPUs to use on each node.")
+@click.option("--master_port",
+              type=int,
+              default=29500,
+              help="(optional) Port used by PyTorch distributed for communication during distributed training.")
+@click.option("--master_addr",
+              type=str,
+              default="127.0.0.1",
+              help="(optional) IP address of node 0, will be inferred via 'hostname -I' if not specified.")
+@click.option(
+    "--launcher",
+    type=click.Choice(['torch', 'openmpi', 'slurm'], case_sensitive=False),
+    default="torch",
+    help="(optional) choose launcher backend for multi-node training. Options currently include PDSH, OpenMPI, SLURM.")
+@click.option("--launcher_args",
+              type=str,
+              default=None,
+              help="(optional) pass launcher specific arguments as a single quoted argument.")
+@click.argument("user_script", type=str)
+@click.argument('user_args', nargs=-1)
+def run(host: str, hostfile: str, num_nodes: int, nprocs_per_node: int, include: str, exclude: str, master_addr: str,
+        master_port: int, launcher: str, launcher_args: str, user_script: str, user_args: str):
+    """
+    To launch multiple processes on a single node or multiple nodes via command line.
+
+    Usage::
+        # run on the current node with all available GPUs
+        colossalai run train.py
+
+        # run with only 2 GPUs on the current node
+        colossalai run --nprocs_per_node 2 train.py
+
+        # run on two nodes
+        colossalai run --host <host1>,<host2> train.py
+
+        # run with hostfile
+        colossalai run --hostfile <file_path> train.py
+    """
+    args_dict = locals()
+    args = Config(args_dict)
+    args.user_args = list(args.user_args)
+    # (lsg) TODO: fix this function
+    # launch_multi_processes(args)

--- a/setup.py
+++ b/setup.py
@@ -215,7 +215,7 @@ setup(
     install_requires=fetch_requirements('requirements/requirements.txt'),
     entry_points='''
         [console_scripts]
-        colossal=colossalai.cli:cli
+        colossalai=colossalai.cli:cli
     ''',
     python_requires='>=3.7',
     classifiers=[


### PR DESCRIPTION
- In the previous implementation, the user options can't be captured, e.g. `colossalai run train.py --arg 1` will raise exception as `arg` will be treated as an unknown thus invalid option. I have fixed this bug in this PR. 
- In addition, I have restructured the module structure. We don't have to define all commands in the `cli.py`. We can define the command in their respective folder and then import them in `cli.py`. This will make the structure look cleaner.
- I have added help message to each option
- The launch function fails at this moment, I will create a separate PR to fix it.