### PR TITLE
[cli] fixed single-node process launching

### DIFF
--- a/colossalai/cli/launcher/__init__.py
+++ b/colossalai/cli/launcher/__init__.py
@@ -25,7 +25,7 @@ from colossalai.context import Config
     "Specify computing devices to NOT use during execution. Mutually exclusive with --include. Formatting is the same as --include."
 )
 @click.option("--num_nodes", type=int, default=-1, help="Total number of worker nodes to use.")
-@click.option("--nprocs_per_node", type=int, default=-1, help="Number of GPUs to use on each node.")
+@click.option("--nproc_per_node", type=int, default=-1, help="Number of GPUs to use on each node.")
 @click.option("--master_port",
               type=int,
               default=29500,
@@ -45,7 +45,7 @@ from colossalai.context import Config
               help="(optional) pass launcher specific arguments as a single quoted argument.")
 @click.argument("user_script", type=str)
 @click.argument('user_args', nargs=-1)
-def run(host: str, hostfile: str, num_nodes: int, nprocs_per_node: int, include: str, exclude: str, master_addr: str,
+def run(host: str, hostfile: str, num_nodes: int, nproc_per_node: int, include: str, exclude: str, master_addr: str,
         master_port: int, launcher: str, launcher_args: str, user_script: str, user_args: str):
     """
     To launch multiple processes on a single node or multiple nodes via command line.
@@ -66,5 +66,4 @@ def run(host: str, hostfile: str, num_nodes: int, nprocs_per_node: int, include:
     args_dict = locals()
     args = Config(args_dict)
     args.user_args = list(args.user_args)
-    # (lsg) TODO: fix this function
-    # launch_multi_processes(args)
+    launch_multi_processes(args)

--- a/colossalai/cli/launcher/multinode_runner.py
+++ b/colossalai/cli/launcher/multinode_runner.py
@@ -1,16 +1,14 @@
 import os
 import sys
 import shutil
-import subprocess
-import warnings
 from shlex import quote
 from abc import ABC, abstractmethod
 
 from colossalai.logging import get_dist_logger
 
-logger = get_dist_logger()
 
 class MultiNodeRunner(ABC):
+
     def __init__(self, args):
         self.args = args
         self.user_arguments = self.args.user_args
@@ -35,6 +33,7 @@ class MultiNodeRunner(ABC):
 
 
 class PDSHRunner(MultiNodeRunner):
+
     def __init__(self, args):
         super().__init__(args)
 
@@ -46,15 +45,13 @@ class PDSHRunner(MultiNodeRunner):
         return "pdsh"
 
     def parse_user_args(self):
-        return list(
-            map(lambda x: x if x.startswith("-") else f"'{x}'",
-                self.args.user_args))
+        return list(map(lambda x: x if x.startswith("-") else f"'{x}'", self.args.user_args))
 
     def get_cmd(self, environment, active_devices, args):
         environment['PDSH_RCMD_TYPE'] = 'ssh'
 
         active_workers = ",".join(active_devices.keys())
-        logger.info("Running on the following workers: %s" % active_workers)
+        print("Running on the following workers: %s" % active_workers)
 
         pdsh_cmd_args = ['pdsh', '-f', str(1024), '-w', active_workers]
 
@@ -65,82 +62,8 @@ class PDSHRunner(MultiNodeRunner):
         # https://linux.die.net/man/1/pdsh
         # %n will be replaced by pdsh command
         colossal_launch = [
-            exports,
-            f"cd {os.path.abspath('.')};",
-            sys.executable, "-u", "-m", 
-            "torch.distributed.launch",
-            f"--nproc_per_node={args.num_gpus}",
-            f"--master_addr={args.master_addr}",
+            exports, f"cd {os.path.abspath('.')};", sys.executable, "-u", "-m", "torch.distributed.launch",
+            f"--nproc_per_node={args.nproc_per_node}", f"--master_addr={args.master_addr}",
             f"--master_port={args.master_port}"
         ]
         return pdsh_cmd_args + colossal_launch + [self.user_script] + self.user_arguments
-
-class OpenMPIRunner(MultiNodeRunner):
-    def __init__(self, args, device_pool):
-        super().__init__(args)
-        self.device_pool = device_pool
-
-    def backend_exists(self):
-        return shutil.which('ompi_info')
-
-    @property
-    def name(self):
-        return "openmpi"
-
-    def get_cmd(self, environment, active_devices):
-        total_process_count = sum(self.device_pool.values())
-
-        mpirun_cmd = [
-            'mpirun',
-            '-n',
-            f'{total_process_count}',
-            '-hostfile',
-            f'{self.args.hostfile}'
-        ]
-
-        export_cmd = []
-        for k, v in self.exports.items():
-            export_cmd += ['-x', f'{k}={quote(v)}']
-
-        python_exec = []
-        python_exec = [sys.executable, "-u", "-m"]
-
-        return mpirun_cmd + export_cmd + python_exec + [self.user_script
-                                                        ] + self.user_arguments
-
-class SLURMRunner(MultiNodeRunner):
-    def __init__(self, args):
-        super().__init__(args)
-
-    def backend_exists(self):
-        return shutil.which('slurm_info')
-
-    @property
-    def name(self):
-        return "slurm"
-
-    def get_cmd(self, environment, active_devices, args):
-
-        assert "-p" in args.launcher_args
-        srun_args = args.launcher_args.strip().split()
-        assert len(srun_args) >= 2, "we need more info about which partition to use."
-        partition_name = srun_args(srun_args.index("-p")+1)
-        slurm_cmd = [
-            'srun',
-            "-p",
-            f"{partition_name}",
-            "--nodes",
-            f"{args.num_nodes}",
-            "--tasks",
-            f"{args.num_gpus}"
-        ]
-
-        export_cmd = []
-        for k, v in self.exports.items():
-            export_cmd += ['-x', f'{k}={quote(v)}']
-
-        python_exec = []
-        python_exec = [sys.executable, "-u", "-m"]
-
-        return slurm_cmd + export_cmd + python_exec + [self.user_script
-                                                        ] + self.user_arguments


### PR DESCRIPTION
I fixed the CLI launching function and it works on a single node now. Multi-node testing will be conducted on TACC later.

I tested with a simple script `test.py`:

```python
import os

print(f'rank: {os.environ['RANK']})
```

The testing commands are given below:
```shell
colossalai run test.py

> rank: 0
> rank: 1
> rank: 2
> rank: 3
> rank: 4
> rank: 5
> rank: 6
> rank: 7

colossalai run --nproc_per_node 4 test.py

> rank: 0
> rank: 1
> rank: 2
> rank: 3
```

On a side note, I also fixed the error message display in our CLI. Conventionally, we use `click.echo` to print any message instead of `print` `logger.info`. Meanwhile, `raise` should be avoided in CLI  implementation as normally CLI does not tell the user at which line the error occurs, but only gives a simple error message instead.