### PR TITLE
[setup] allow installation with python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -217,7 +217,7 @@ setup(
         [console_scripts]
         colossalai=colossalai.cli:cli
     ''',
-    python_requires='>=3.7',
+    python_requires='>=3.6',
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
Colossal-AI is compatible with Python 3.6.