### PR TITLE
[cudnn] set False to cudnn benchmark by default

### DIFF
--- a/colossalai/initialize.py
+++ b/colossalai/initialize.py
@@ -270,7 +270,7 @@ def initialize(model: nn.Module,
             ranks=[0])
 
     # cudnn
-    cudnn_benchmark = config.get('cudnn_benchmark', True)
+    cudnn_benchmark = config.get('cudnn_benchmark', False)
     cudnn_deterministic = config.get('cudnn_deterministic', False)
     torch.backends.cudnn.benchmark = cudnn_benchmark
     torch.backends.cudnn.deterministic = cudnn_deterministic


### PR DESCRIPTION
Fixed #1058 , set cudnn benchmark to false so that it will not repeatedly run benchmarking when inputs are of varying sizes.

If the user wants to turn on cudnn, they can have `cudnn_benchmark = True` in `config.py`.