### PR TITLE
[context] maintain the context object in with statement

### DIFF
--- a/colossalai/utils/model/utils.py
+++ b/colossalai/utils/model/utils.py
@@ -72,6 +72,7 @@ class InsertPostInitMethodToModuleSubClasses(object):
         torch.nn.modules.module.Module.__init_subclass__ = classmethod(_init_subclass)
 
         self._pre_context_exec()
+        return self
 
     def __exit__(self, exc_type, exc_value, traceback):
 


### PR DESCRIPTION
The `InsertPostInitMethodToModuleSubClasses` context manager does not return the object in `with` statement, this issue fixed this problem so that the attributes of the contexts can still be accessed after `with` statement.

Previous:
```python
>>> with InsertPostInitMethodToModuleSubClasses() as ctx:
>>>        model = resnet18()
>>> print(ctx)
None
```

Now:
```python
>>> with InsertPostInitMethodToModuleSubClasses() as ctx:
>>>        model = resnet18()
>>> print(ctx)
<colossalai.utils.model.colo_init_context.ColoInitContext at 0x7f75d031bcd0>
```
