### PR TITLE
[engine] fixed empty op hook check

### DIFF
--- a/colossalai/engine/_base_engine.py
+++ b/colossalai/engine/_base_engine.py
@@ -92,7 +92,10 @@ class Engine:
             self._schedule = NonPipelineSchedule()
         if self.uses_pipeline:
             self._schedule.pre_processing(self)
-        register_ophooks_recursively(self._model, self._ophook_list)
+
+        #register hook if any
+        if len(self._ophook_list) > 0:
+            register_ophooks_recursively(self._model, self._ophook_list)
 
     @property
     def ophooks(self):

--- a/colossalai/engine/ophooks/utils.py
+++ b/colossalai/engine/ophooks/utils.py
@@ -1,4 +1,3 @@
-from numpy import isin
 import torch
 from typing import List, Callable, Optional
 

--- a/colossalai/engine/ophooks/utils.py
+++ b/colossalai/engine/ophooks/utils.py
@@ -1,3 +1,4 @@
+from numpy import isin
 import torch
 from typing import List, Callable, Optional
 
@@ -85,11 +86,15 @@ class PostBackwardFunction(torch.autograd.Function):
 
 
 def register_ophooks_recursively(module: torch.nn.Module,
-                                 ophook_list: List[BaseOpHook] = None,
+                                 ophook_list: List[BaseOpHook],
                                  name: str = "",
                                  filter_fn: Optional[Callable] = None):
     r"""Recursilvely register pre/post hooks for all submodules in the module in FWD and BWD."""
     assert isinstance(module, torch.nn.Module)
+    assert isinstance(ophook_list, (list, tuple))
+    assert len(ophook_list) > 0, 'expected at least 1 hook in the argument ophook_list but found 0'
+    for hook in ophook_list:
+            assert (isinstance(hook, BaseOpHook))
 
     # Add hooks for submodules
     for child_name, child in module.named_children():
@@ -102,10 +107,6 @@ def register_ophooks_recursively(module: torch.nn.Module,
     # return from flitered module
     if filter_fn is not None and filter_fn(module):
         return
-
-    if ophook_list is not None:
-        for hook in ophook_list:
-            assert (isinstance(hook, BaseOpHook))
 
     def _pre_forward_module_hook(submodule, *args):
         for hook in ophook_list:


### PR DESCRIPTION
Fixed #1095 . The bug in the issue is because that empty hooks are registered on the modules and these hooks seem to incur extra memory, perhaps there are some underlying tensor cloning. With this PR, this bug can be fixed. Some experiment results are shown below.

Model: ResNet101
Dataset: CIFAR10 (resize to 224)
Optim: Adam
Batch size: 128
#GPU: 1

| Experiment | Max CUDA memory allocated / GB | 
| -  | - |
| without engine | 8.25 |
| with engine (before fix) | 16.49 |
| with engine (after fix)  | 8.25 |