### PR TITLE
[tensor] refactor param op hook

### DIFF
--- a/colossalai/tensor/__init__.py
+++ b/colossalai/tensor/__init__.py
@@ -5,10 +5,10 @@ from .colo_parameter import ColoParameter
 from .utils import convert_parameter, named_params_with_colotensor
 from . import distspec
 from .dist_spec_mgr import DistSpecManager
-from .param_op_hook import ParamOpHook, use_param_op_hooks
+from .param_op_hook import ParamOpHook, ParamOpHookManager
 from .chunk import ChunkManager, TensorState
 
 __all__ = [
     'ColoTensor', 'convert_parameter', 'ComputePattern', 'TensorSpec', 'ParallelAction', 'named_params_with_colotensor',
-    'ColoParameter', 'distspec', 'DistSpecManager', 'ParamOpHook', 'use_param_op_hooks', 'ChunkManager', 'TensorState'
+    'ColoParameter', 'distspec', 'DistSpecManager', 'ParamOpHook', 'ParamOpHookManager', 'ChunkManager', 'TensorState'
 ]

--- a/colossalai/tensor/param_op_hook.py
+++ b/colossalai/tensor/param_op_hook.py
@@ -5,6 +5,11 @@ from typing import List, Tuple, Any
 
 
 class ParamOpHook(ABC):
+    """Hook which is triggered by each operation when operands contain ColoParameter.
+    To customize it, you must inherit this abstract class, and implement ``pre_forward``,
+    ``post_forward``, ``pre_backward`` and ``post_backward``. These four methods take a list
+    of ColoParameter.
+    """
 
     @abstractmethod
     def pre_forward(self, params: List[torch.Tensor]) -> None:
@@ -24,11 +29,23 @@ class ParamOpHook(ABC):
 
 
 class ParamOpHookManager:
+    """Manage your param op hooks. It only has static methods.
+    The only static method you should call is ``use_hooks(*hooks)``.
+    """
     hooks: Tuple[ParamOpHook, ...] = tuple()
 
     @staticmethod
     @contextmanager
     def use_hooks(*hooks: ParamOpHook):
+        """Change the param op hooks you use. Nested calling is allowed.
+
+        Example::
+            >>> with ParamOpHookManager.use_hooks(*hooks):
+            >>>     do_something()
+            >>>     with ParamOpHookManager.use_hooks():
+            >>>         // clear hooks
+            >>>         do_something()
+        """
         try:
             old_param_op_hooks = ParamOpHookManager.hooks
             ParamOpHookManager.hooks = hooks

--- a/colossalai/tensor/param_op_hook.py
+++ b/colossalai/tensor/param_op_hook.py
@@ -1,7 +1,7 @@
 import torch
 from contextlib import contextmanager
 from abc import ABC, abstractmethod
-from typing import List, Tuple
+from typing import List, Tuple, Any
 
 
 class ParamOpHook(ABC):
@@ -23,8 +23,52 @@ class ParamOpHook(ABC):
         pass
 
 
-class _ParamOpHookWrapper:
+class ParamOpHookManager:
     hooks: Tuple[ParamOpHook, ...] = tuple()
+
+    @staticmethod
+    @contextmanager
+    def use_hooks(*hooks: ParamOpHook):
+        try:
+            old_param_op_hooks = ParamOpHookManager.hooks
+            ParamOpHookManager.hooks = hooks
+            yield
+        finally:
+            ParamOpHookManager.hooks = old_param_op_hooks
+
+    @staticmethod
+    def _trigger_pre_forward(params: List[torch.Tensor]) -> None:
+        for hook in ParamOpHookManager.hooks:
+            hook.pre_forward(params)
+
+    @staticmethod
+    def _trigger_post_forward(params: List[torch.Tensor]) -> None:
+        for hook in ParamOpHookManager.hooks:
+            hook.post_forward(params)
+
+    @staticmethod
+    def _trigger_pre_backward(params: List[torch.Tensor]) -> None:
+        for hook in ParamOpHookManager.hooks:
+            hook.pre_backward(params)
+
+    @staticmethod
+    def _trigger_post_backward(params: List[torch.Tensor]) -> None:
+        for hook in ParamOpHookManager.hooks:
+            hook.post_backward(params)
+
+    @staticmethod
+    def pre_op(params: List[torch.Tensor], *args: Any) -> Any:
+        ParamOpHookManager._trigger_pre_forward(params)
+        return PreFwdPostBwd.apply(params, *args)
+
+    @staticmethod
+    def post_op(params: List[torch.Tensor], args: Any) -> Any:
+        ParamOpHookManager._trigger_post_backward(params)
+        return PostFwdPreBwd.apply(params, args)
+
+    @staticmethod
+    def has_hook() -> bool:
+        return len(ParamOpHookManager.hooks) > 0
 
 
 class PreFwdPostBwd(torch.autograd.Function):
@@ -32,16 +76,13 @@ class PreFwdPostBwd(torch.autograd.Function):
     @staticmethod
     def forward(ctx, params, *args):
         ctx.params = params
-        for hook in _ParamOpHookWrapper.hooks:
-            hook.pre_forward(ctx.params)
         if len(args) == 1:
             return args[0]
         return args
 
     @staticmethod
     def backward(ctx, *grads):
-        for hook in _ParamOpHookWrapper.hooks:
-            hook.post_backward(ctx.params)
+        ParamOpHookManager._trigger_post_backward(ctx.params)
         return (None,) + grads
 
 
@@ -50,22 +91,9 @@ class PostFwdPreBwd(torch.autograd.Function):
     @staticmethod
     def forward(ctx, params, args):
         ctx.params = params
-        for hook in _ParamOpHookWrapper.hooks:
-            hook.post_forward(params)
         return args
 
     @staticmethod
     def backward(ctx, *grads):
-        for hook in _ParamOpHookWrapper.hooks:
-            hook.pre_backward(ctx.params)
+        ParamOpHookManager._trigger_pre_backward(ctx.params)
         return (None,) + grads
-
-
-@contextmanager
-def use_param_op_hooks(*hooks: ParamOpHook):
-    try:
-        old_param_op_hooks = _ParamOpHookWrapper.hooks
-        _ParamOpHookWrapper.hooks = hooks
-        yield
-    finally:
-        _ParamOpHookWrapper.hooks = old_param_op_hooks

--- a/colossalai/tensor/param_op_hook.py
+++ b/colossalai/tensor/param_op_hook.py
@@ -80,7 +80,7 @@ class ParamOpHookManager:
 
     @staticmethod
     def post_op(params: List[torch.Tensor], args: Any) -> Any:
-        ParamOpHookManager._trigger_post_backward(params)
+        ParamOpHookManager._trigger_post_forward(params)
         return PostFwdPreBwd.apply(params, args)
 
     @staticmethod


### PR DESCRIPTION
`torch.autograd.Function` ensures the device of original inputs and grads are the same. Since zero hook may change the device of input in pre fwd, we execute pre fwd out of `autograd.Function`.