### PR TITLE
[hotfix] fix param op hook

### DIFF
--- a/colossalai/tensor/colo_parameter.py
+++ b/colossalai/tensor/colo_parameter.py
@@ -11,17 +11,11 @@ def filter_args(func, *args):
     return [arg for arg in args if func(arg)]
 
 
-def unpack_args(args):
-    if len(args) == 1:
-        return args[0]
-    return args
-
-
 def replace_args(args, kwargs, new_args):
     args = new_args[:len(args)]
     for k, v in zip(kwargs.keys(), new_args[len(args):]):
         kwargs[k] = v
-    return unpack_args(args), kwargs
+    return tuple(args), kwargs
 
 
 class ColoParameter(ColoTensor, torch.nn.Parameter):

--- a/colossalai/tensor/colo_parameter.py
+++ b/colossalai/tensor/colo_parameter.py
@@ -11,7 +11,7 @@ def filter_args(func, *args):
     return [arg for arg in args if func(arg)]
 
 
-def unpack_args(*args):
+def unpack_args(args):
     if len(args) == 1:
         return args[0]
     return args

--- a/colossalai/tensor/param_op_hook.py
+++ b/colossalai/tensor/param_op_hook.py
@@ -2,6 +2,7 @@ import torch
 from contextlib import contextmanager
 from abc import ABC, abstractmethod
 from typing import List, Tuple, Any
+from colossalai.tensor.colo_tensor import ColoTensor
 
 
 class ParamOpHook(ABC):
@@ -76,12 +77,16 @@ class ParamOpHookManager:
     @staticmethod
     def pre_op(params: List[torch.Tensor], *args: Any) -> Any:
         ParamOpHookManager._trigger_pre_forward(params)
-        return PreFwdPostBwd.apply(params, *args)
+        args_info = _get_colo_tensors_info(*args)
+        rets = PreFwdPostBwd.apply(params, *args)
+        return _update_colo_tensors(args_info, *rets)
 
     @staticmethod
-    def post_op(params: List[torch.Tensor], args: Any) -> Any:
+    def post_op(params: List[torch.Tensor], arg: Any) -> Any:
         ParamOpHookManager._trigger_post_forward(params)
-        return PostFwdPreBwd.apply(params, args)
+        arg_info = _get_colo_tensors_info(arg)
+        ret = PostFwdPreBwd.apply(params, arg)
+        return _update_colo_tensors(arg_info, ret)
 
     @staticmethod
     def has_hook() -> bool:
@@ -93,9 +98,7 @@ class PreFwdPostBwd(torch.autograd.Function):
     @staticmethod
     def forward(ctx, params, *args):
         ctx.params = params
-        if len(args) == 1:
-            return args[0]
-        return args
+        return _unpack_args(args)
 
     @staticmethod
     def backward(ctx, *grads):
@@ -114,3 +117,29 @@ class PostFwdPreBwd(torch.autograd.Function):
     def backward(ctx, *grads):
         ParamOpHookManager._trigger_pre_backward(ctx.params)
         return (None,) + grads
+
+
+def _unpack_args(args):
+    if len(args) == 1:
+        return args[0]
+    return args
+
+
+def _get_colo_tensors_info(*args):
+    info = []
+    for arg in args:
+        if isinstance(arg, ColoTensor):
+            info.append((arg.__class__, arg.spec))
+        else:
+            info.append(None)
+    return info
+
+
+def _update_colo_tensors(info, *args):
+    ret = []
+    for t_info, arg in zip(info, args):
+        if t_info is not None:
+            t_cls, spec = t_info
+            arg = t_cls.from_torch_tensor(arg, spec=spec)
+        ret.append(arg)
+    return _unpack_args(ret)


### PR DESCRIPTION
`torch.autograd.Function` will convert all return tensors of `forward()` to `torch.Tensor`. For `ColoTensor` and `ColoParameter`, `spec` will be lost. We have to store the specifications and reconstruct `ColoTensor`/`ColoParameter` after applying `torch.autograd.Function`.

ZeRO + TP is also supported.