### PR TITLE
[fx] added ndim property to proxy

### DIFF
--- a/colossalai/fx/proxy.py
+++ b/colossalai/fx/proxy.py
@@ -57,6 +57,10 @@ class ColoProxy(Proxy):
         self._assert_meta_data_is_tensor()
         return self.meta_data.shape
 
+    @property
+    def ndim(self):
+        return self.dim()
+
     def dim(self):
         self._assert_meta_data_is_tensor()
         return self.meta_data.dim()


### PR DESCRIPTION
This PR fixes the tracing problem of the latest timm library. The root cause is that the latest code contains if statements like `if x.ndim == 4`.