### PR TITLE
[workflow] fixed trigger condition for 8-gpu unit test

### DIFF
--- a/.github/workflows/build_gpu_8.yml
+++ b/.github/workflows/build_gpu_8.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Unit Testing
         run: |
           gpu_used=$(nvidia-smi -i 0 --query-gpu=memory.used --format=csv,noheader,nounits)
-          [ "$gpu_used" -gt "100" ] && PYTHONPATH=$PWD pytest tests
+          [ "$gpu_used" -le "100" ] && PYTHONPATH=$PWD pytest tests
         env:
           DATA: /data/scratch/cifar-10
           


### PR DESCRIPTION
The condition for this test should be that memory used is less than 100 MB so it deems that the GPU is not in use.