### PR TITLE
[zero] zero optim state_dict takes only_rank_0

### DIFF
--- a/tests/test_zero/test_zero_optim_state_dict.py
+++ b/tests/test_zero/test_zero_optim_state_dict.py
@@ -45,7 +45,8 @@ def check_state_dict(state_dict, torch_state_dict):
 @parameterize('use_chunk', [False, True])
 @parameterize('use_zero', [False, True])
 @parameterize('placement_policy', ['cuda', 'cpu', 'auto'])
-def run_zero_optim_state_dict(use_chunk, use_zero, placement_policy):
+@parameterize('only_rank_0', [False, True])
+def run_zero_optim_state_dict(use_chunk, use_zero, placement_policy, only_rank_0):
     get_components_func = non_distributed_component_funcs.get_callable('gpt2')
     model_builder, train_dataloader, test_dataloader, optimizer_class, criterion = get_components_func()
 
@@ -77,7 +78,7 @@ def run_zero_optim_state_dict(use_chunk, use_zero, placement_policy):
     check_load_state_dict(optim, torch_optim)
 
     state_dict = optim.state_dict()
-    if pg.rank() == 0:
+    if not only_rank_0 or pg.rank() == 0:
         check_state_dict(state_dict, torch_state_dict)
 
 

--- a/tests/test_zero/test_zero_optim_state_dict.py
+++ b/tests/test_zero/test_zero_optim_state_dict.py
@@ -77,7 +77,7 @@ def run_zero_optim_state_dict(use_chunk, use_zero, placement_policy, only_rank_0
     optim.load_state_dict(torch_state_dict)
     check_load_state_dict(optim, torch_optim)
 
-    state_dict = optim.state_dict()
+    state_dict = optim.state_dict(only_rank_0)
     if not only_rank_0 or pg.rank() == 0:
         check_state_dict(state_dict, torch_state_dict)
 


### PR DESCRIPTION
Use `only_rank_0` to control `zero_optim.state_dict()`. If true, only DP rank 0 returns global state dict, and other ranks return None. This saves memory usage. Otherwise, all ranks return global state dict.