### PR TITLE
[fx] fixed indentation error in checkpointing codegen

### DIFF
--- a/colossalai/fx/codegen/activation_checkpoint_codegen.py
+++ b/colossalai/fx/codegen/activation_checkpoint_codegen.py
@@ -373,10 +373,10 @@ if codegen_available:
             code = ''.join(body)
             code = '\n'.join('    ' + line for line in code.split('\n'))
             fn_code = f"""
-    {wrap_stmts}
+{wrap_stmts}
 
-    {prologue}
-    {code}"""
+{prologue}
+{code}"""
             return PythonCode(fn_code, globals_)
 
 else:


### PR DESCRIPTION
After the previous PR #1359 , the codegen for torch 1.12 was broken due to the indentation error, this PR fixed this problem.

The test with torch 1.12 is given below:

<img width="1920" alt="Screenshot 2022-07-29 at 12 54 28 PM" src="https://user-images.githubusercontent.com/31818963/181685640-3055d9b9-317f-4ee3-83ea-9bd30f8a24b5.png">

