### PR TITLE
[fx] patched torch.full for huggingface opt

### DIFF
--- a/colossalai/fx/tracer/meta_patch/patched_function/torch_ops.py
+++ b/colossalai/fx/tracer/meta_patch/patched_function/torch_ops.py
@@ -132,3 +132,9 @@ def torch_tensor_repeat_interleave(self, repeats, dim=None, *, output_size=None)
 @meta_patched_function.register(torch.roll)
 def torch_roll(input, shifts, dims=None):
     return torch.empty(input.shape, device='meta')
+
+
+@meta_patched_function.register(torch.full)
+def torch_full(size, fill_value, *, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False):
+    assert out is None, 'assigning result to out is not supported yet'
+    return torch.empty(size, device='meta', dtype=dtype, layout=layout, requires_grad=requires_grad)


### PR DESCRIPTION
As Hugging Face Transformers library is updated from 4.20.0 to 4.21.0, the OPT model code is updated, leading to a CI error. This PR added the required function patch to fix this error.