### PR TITLE
reorganize the inheritance struct of FreqCacheEmbedding

### DIFF
--- a/colossalai/nn/parallel/layers/cache_embedding/freq_aware_embedding.py
+++ b/colossalai/nn/parallel/layers/cache_embedding/freq_aware_embedding.py
@@ -40,13 +40,12 @@ class FreqAwareEmbeddingBag(BaseEmbeddingBag):
         self._preprocess(_weight, cuda_row_num, ids_freq_mapping, warmup_ratio, buffer_size)
 
     def _weight_alloc(self, dtype, device):
-        return torch.empty(self.num_embeddings, self.embedding_dim, dtype=dtype, device=device, pin_memory=True)
-
-    @torch.no_grad()
-    def init_parameters(self):
-        self.weight.data.uniform_(-1 / self.num_embeddings, 1 / self.num_embeddings)
-        if self.padding_idx is not None:
-            self.weight[self.padding_idx].fill_(0)
+        weight = torch.empty(self.num_embeddings, self.embedding_dim, dtype=dtype, device=device, pin_memory=True)
+        with torch.no_grad():
+            weight.data.uniform_(-1 / self.num_embeddings, 1 / self.num_embeddings)
+            if self.padding_idx is not None:
+                weight[self.padding_idx].fill_(0)
+        return weight
 
     def _preprocess(self,
                     weight,

--- a/colossalai/nn/parallel/layers/cache_embedding/freq_aware_embedding.py
+++ b/colossalai/nn/parallel/layers/cache_embedding/freq_aware_embedding.py
@@ -9,15 +9,51 @@ from torch.nn.parameter import Parameter
 
 class FreqAwareEmbeddingBag(BaseEmbeddingBag):
 
-    def __init__(self, num_embeddings, embedding_dim, dtype=None, *args, **kwargs):
-        super(FreqAwareEmbeddingBag, self).__init__(num_embeddings, embedding_dim, *args, **kwargs)
-        self._weight = torch.randn(self.num_embeddings, self.embedding_dim, device='cpu', dtype=dtype)
+    def __init__(
+        self,
+        num_embeddings,
+        embedding_dim,
+        padding_idx=None,
+        max_norm=None,
+        norm_type=2.,
+        scale_grad_by_freq=False,
+        sparse=False,
+        _weight=None,
+        mode='mean',
+        include_last_offset=False,
+        dtype=None,
+        device=None,
+        cuda_row_num=0,
+        ids_freq_mapping=None,
+        warmup_ratio=0.7,
+        buffer_size=50_000,
+    ):
+        super(FreqAwareEmbeddingBag, self).__init__(num_embeddings, embedding_dim, padding_idx, max_norm, norm_type,
+                                                    scale_grad_by_freq, sparse, mode, include_last_offset)
 
-    def preprocess(self,
-                   cuda_row_num: int,
-                   ids_freq_mapping: Optional[List[int]] = None,
-                   warmup_ratio=0.7,
-                   buffer_size=50_000):
+        if _weight is None:
+            _weight = self._weight_alloc(dtype, device)
+        else:
+            _weight = _weight
+
+        # configure weight & cache
+        self._preprocess(_weight, cuda_row_num, ids_freq_mapping, warmup_ratio, buffer_size)
+
+    def _weight_alloc(self, dtype, device):
+        return torch.empty(self.num_embeddings, self.embedding_dim, dtype=dtype, device=device, pin_memory=True)
+
+    @torch.no_grad()
+    def init_parameters(self):
+        self.weight.data.uniform_(-1 / self.num_embeddings, 1 / self.num_embeddings)
+        if self.padding_idx is not None:
+            self.weight[self.padding_idx].fill_(0)
+
+    def _preprocess(self,
+                    weight,
+                    cuda_row_num: int,
+                    ids_freq_mapping: Optional[List[int]] = None,
+                    warmup_ratio=0.7,
+                    buffer_size=50_000):
         """
         Called after initialized. 
         Reorder the weight rows according to the ids_freq_mapping.
@@ -27,7 +63,7 @@ class FreqAwareEmbeddingBag(BaseEmbeddingBag):
             ids_freq_mapping (List[int]): a list, idx is id number, value is freq
             warmup_ratio (float): the amount of rows preloaded in cuda cache
         """
-        self.cache_weight_mgr = CachedParamMgr(self._weight, cuda_row_num, buffer_size)
+        self.cache_weight_mgr = CachedParamMgr(weight, cuda_row_num, buffer_size)
         self.cache_weight_mgr.reorder(ids_freq_mapping, warmup_ratio)
 
     def forward(self, indices, offsets=None, per_sample_weights=None):
@@ -42,14 +78,16 @@ class FreqAwareEmbeddingBag(BaseEmbeddingBag):
 
     @property
     def weight(self):
-        assert self.cache_weight_mgr is not None
-        return self.cache_weight_mgr.cpu_weight.narrow(0, 0, self.num_embeddings)
+        return self.cache_weight_mgr.weight
 
     def named_parameters(self, prefix: str = '', recurse: bool = True) -> Iterator[Tuple[str, Parameter]]:
         yield 'weight', self.cache_weight_mgr.cuda_cached_weight
 
     def parameters(self, recurse: bool = True) -> Iterator[Parameter]:
         yield self.cache_weight_mgr.cuda_cached_weight
+
+
+############################# Perf Log ###################################
 
     @property
     def num_hits_history(self):

--- a/colossalai/nn/parallel/layers/cache_embedding/parallel_freq_aware_embedding.py
+++ b/colossalai/nn/parallel/layers/cache_embedding/parallel_freq_aware_embedding.py
@@ -2,12 +2,12 @@ import torch
 import torch.nn.functional as F
 from typing import List, Optional, Iterator, Tuple
 
-from .base_embedding import BaseEmbeddingBag
+from .freq_aware_embedding import FreqAwareEmbeddingBag
 from .cache_mgr import CachedParamMgr
 from torch.nn.parameter import Parameter
 from colossalai.nn._ops._utils import dual_all_to_all
 
-from colossalai.tensor import ColoParameter, ShardSpec, ComputePattern, ProcessGroup, ColoTensorSpec
+from colossalai.tensor import ColoParameter, ShardSpec, ComputePattern, ProcessGroup, ColoTensorSpec, ColoTensor
 
 
 def get_partition(embedding_dim, rank, world_size) -> Tuple[int, int, bool]:
@@ -29,71 +29,48 @@ def get_partition(embedding_dim, rank, world_size) -> Tuple[int, int, bool]:
     return offset, offset + size_list[rank], False
 
 
-class ParallelFreqAwareEmbeddingBag(BaseEmbeddingBag):
+class ParallelFreqAwareEmbeddingBag(FreqAwareEmbeddingBag):
 
-    def __init__(self,
-                 num_embeddings,
-                 embedding_dim,
-                 padding_idx=None,
-                 max_norm=None,
-                 norm_type=2.,
-                 scale_grad_by_freq=False,
-                 sparse=False,
-                 _weight=None,
-                 mode='mean',
-                 include_last_offset=False,
-                 dtype=None,
-                 debug=True):
-        super(ParallelFreqAwareEmbeddingBag,
-              self).__init__(num_embeddings, embedding_dim, padding_idx, max_norm, norm_type, scale_grad_by_freq,
-                             sparse, mode, include_last_offset)
-
+    def __init__(
+        self,
+        num_embeddings,
+        embedding_dim,
+        padding_idx=None,
+        max_norm=None,
+        norm_type=2.,
+        scale_grad_by_freq=False,
+        sparse=False,
+        _weight=None,
+        mode='mean',
+        include_last_offset=False,
+        dtype=None,
+        device=None,
+        cuda_row_num=0,
+        ids_freq_mapping=None,
+        warmup_ratio=0.7,
+        buffer_size=50_000,
+    ):
         self.rank = torch.distributed.get_rank()
         self.world_size = torch.distributed.get_world_size()
-        self.debug = debug
 
         self.partition_start_index, self.partition_end_index, divisible = get_partition(
             embedding_dim, self.rank, self.world_size)
         self.embedding_dim_per_partition = self.partition_end_index - self.partition_start_index
 
-        if _weight is None:
-            colo_tensor_spec = ColoTensorSpec(pg=ProcessGroup(tp_degree=self.world_size),
-                                              dist_attr=ShardSpec(dims=[-1], num_partitions=[self.world_size]),
-                                              compute_attr=ComputePattern.TP1D)
-            self._weight = ColoParameter.from_torch_tensor(torch.empty(self.num_embeddings,
-                                                                       self.embedding_dim_per_partition,
-                                                                       device='cpu',
-                                                                       dtype=dtype),
-                                                           requires_grad=True,
-                                                           spec=colo_tensor_spec)
-            self.init_parameters()
-        else:
-            assert isinstance(_weight, ColoParameter), "initialized weight must in type of ColoParameter"
-            self._weight = _weight
+        super(ParallelFreqAwareEmbeddingBag,
+              self).__init__(num_embeddings, embedding_dim, padding_idx, max_norm, norm_type, scale_grad_by_freq,
+                             sparse, _weight, mode, include_last_offset, dtype, device, cuda_row_num, ids_freq_mapping,
+                             warmup_ratio, buffer_size)
 
-    @property
-    def weight(self):
-        return self.cache_weight_mgr.cpu_weight
-
-    def named_parameters(self, prefix: str = '', recurse: bool = True) -> Iterator[Tuple[str, Parameter]]:
-        yield 'weight', self.cache_weight_mgr.cuda_cached_weight
-
-    def parameters(self, recurse: bool = True) -> Iterator[Parameter]:
-        yield self.cache_weight_mgr.cuda_cached_weight
-
-    @torch.no_grad()
-    def init_parameters(self):
-        self._weight.data.uniform_(-1 / self.num_embeddings, 1 / self.num_embeddings)
-        if self.padding_idx is not None:
-            self._weight[self.padding_idx].fill_(0)
-
-    def preprocess(self,
-                   cuda_row_num: int,
-                   ids_freq_mapping: Optional[List[int]] = None,
-                   warmup_ratio: float = 0.7,
-                   buffer_size: int = 50_000):
-        self.cache_weight_mgr = CachedParamMgr(self._weight, cuda_row_num, buffer_size=buffer_size)
-        self.cache_weight_mgr.reorder(ids_freq_mapping, warmup_ratio)
+    def _weight_alloc(self, dtype, device):
+        colo_tensor_spec = ColoTensorSpec(pg=ProcessGroup(tp_degree=self.world_size),
+                                          dist_attr=ShardSpec(dims=[-1], num_partitions=[self.world_size]),
+                                          compute_attr=ComputePattern.TP1D)
+        return ColoTensor.from_torch_tensor(torch.empty(self.num_embeddings,
+                                                        self.embedding_dim_per_partition,
+                                                        device=device,
+                                                        dtype=dtype),
+                                            spec=colo_tensor_spec)
 
     def forward(self, indices, offsets=None, per_sample_weights=None, shape_hook=None, scatter_dim=0, gather_dim=-1):
         with torch.no_grad():
@@ -107,29 +84,42 @@ class ParallelFreqAwareEmbeddingBag(BaseEmbeddingBag):
             output_shard = shape_hook(output_shard)
 
         output_full = dual_all_to_all(output_shard,
-                                      self._weight.get_process_group(),
+                                      self.weight.get_process_group(),
                                       scatter_dim=scatter_dim,
                                       gather_dim=gather_dim)
         return output_full
 
     @classmethod
-    def from_pretrained(cls,
-                        embedding: torch.Tensor,
-                        freeze: bool = True,
-                        padding_idx: Optional[int] = None,
-                        max_norm: Optional[float] = None,
-                        norm_type: float = 2.,
-                        scale_grad_by_freq: bool = False,
-                        sparse: bool = False,
-                        mode: str = 'mean',
-                        include_last_offset: bool = False,
-                        debug: bool = True,
-                        cuda_row_num: int = 100_000,
-                        ids_freq_mapping: Optional[List[int]] = None,
-                        warmup_ratio: float = 0.7) -> 'ParallelFreqAwareEmbeddingBag':
+    def from_pretrained(
+        cls,
+        embedding: torch.Tensor,
+        freeze: bool = True,
+        padding_idx: Optional[int] = None,
+        max_norm: Optional[float] = None,
+        norm_type: float = 2.,
+        scale_grad_by_freq: bool = False,
+        sparse: bool = False,
+        mode: str = 'mean',
+        include_last_offset: bool = False,
+        cuda_row_num: int = 100_000,
+        ids_freq_mapping: Optional[List[int]] = None,
+        warmup_ratio: float = 0.7,
+        buffer_size: int = 50_000,
+    ) -> 'ParallelFreqAwareEmbeddingBag':
         rows, cols = embedding.shape
-        embedding_bag = cls(rows, cols, padding_idx, max_norm, norm_type, scale_grad_by_freq, sparse, embedding, mode,
-                            include_last_offset, debug)
-        embedding_bag.preprocess(cuda_row_num, ids_freq_mapping, warmup_ratio)
+        embedding_bag = cls(rows,
+                            cols,
+                            padding_idx,
+                            max_norm,
+                            norm_type,
+                            scale_grad_by_freq,
+                            sparse,
+                            embedding,
+                            mode,
+                            include_last_offset,
+                            cuda_row_num=cuda_row_num,
+                            ids_freq_mapping=ids_freq_mapping,
+                            warmup_ratio=warmup_ratio,
+                            buffer_size=buffer_size)
         embedding_bag.cache_weight_mgr.cuda_cached_weight.requires_grad_ = not freeze
         return embedding_bag


### PR DESCRIPTION
1. Remove the redundant weight in FreqCacheEmbedding to resolve this issue: https://github.com/hpcaitech/ColossalAI/issues/1440
2. reorganize the inheritance structure of FreqCacheEmbedding to remove redundant code in ParallelFreqCacheEmbedding. 
3. I also leave an interface in CacheParamMgr, so that FreqCacheEmbedding is compatible with vanilla PyTorch EmbeddingBag. But this implementation should be delayed.

![Uq3tUGyuNX](https://user-images.githubusercontent.com/34452939/184294580-c853946f-4259-46c0-94f1-099f49e1a74e.jpg)
