### PR TITLE
[autoparallel] integrate auto parallel with torch fx

### DIFF
--- a/colossalai/auto_parallel/solver/__init__.py
+++ b/colossalai/auto_parallel/solver/__init__.py
@@ -1,0 +1,6 @@
+from .operator_handler import OperatorHandler
+from .dot_handler import DotHandler
+from .conv_handler import ConvHandler
+from .sharding_strategy import ShardingStrategy, StrategiesVector
+
+__all__ = ['OperatorHandler', 'DotHandler', 'ConvHandler', 'StrategiesVector', 'ShardingStrategy']

--- a/colossalai/auto_parallel/solver/sharding_strategy.py
+++ b/colossalai/auto_parallel/solver/sharding_strategy.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 from colossalai.tensor.sharding_spec import ShardingSpec
 from typing import Dict, List
+from torch.fx.node import Node
+
+__all__ = ['ShardingStrategy', 'StrategiesVector']
 
 
 @dataclass
@@ -30,26 +33,21 @@ class ShardingStrategy:
     input_shardings: ShardingSpec = None
 
 
-class StrategiesVector:
+class StrategiesVector(list):
     '''
     Each node in fx graph will have a corresponding StrategiesVector, to store all the possible
     strategies of the node.
 
     Argument:
-        node(Node): node to build corresponding strategies_vector.
-        in_nodes(List[Node]): input nodes in the argument list of the node.
-        following_nodes(List[Node]): the nodes take the target node as their argument.
-        strategies(List[ShardingStrategy]): enumerate all the possible sharding strategies of the node.
+        node (Node): node for which the list of sharding strategies are generated.
     '''
 
-    def __init__(self, node, in_nodes, following_nodes=None, strategies=None):
+    def __init__(self, node: Node):
+        super().__init__()
         self.node = node
-        self.in_nodes = in_nodes
-        self.following_nodes = following_nodes
-
-        if strategies is None:
-            strategies = []
-        self.strategies = strategies
+        # fetch its input and output nodes
+        self.predecessor_nodes = list(node._input_nodes.keys())
+        self.successor_ndoes = list(node.users.keys())
 
     def check_merge(self):
         pass

--- a/tests/test_auto_parallel/test_dot_handler.py
+++ b/tests/test_auto_parallel/test_dot_handler.py
@@ -47,7 +47,9 @@ def test_dot_handler():
     # [x, mul, linear, output]
     nodes = [node for node in gm.graph.nodes]
 
-    strategies_for_input = []
+    # find the sharding strategies for the input node of the conv node
+    # strategies_for_input = [[R, R, R, R], [R, S0, R, R], [R, S1, R, R], [S0, R, R, R], [S0, S1, R, R], [S1, R, R, R], [S1, S0, R, R]]
+    strategies_vector_for_input = StrategiesVector(node=nodes[1])
     sharding_option = (None, 0, 1)
     for first_sharding_index in sharding_option:
         for second_sharding_index in sharding_option:
@@ -67,26 +69,19 @@ def test_dot_handler():
             sharding_spec = ShardingSpec(device_mesh=device_mesh,
                                          entire_shape=entire_shape,
                                          sharding_sequence=sharding_sequence)
-            strategies_for_input.append(sharding_spec)
-
-    # strategies_for_input = [[R, R, R, R], [R, S0, R, R], [R, S1, R, R], [S0, R, R, R], [S0, S1, R, R], [S1, R, R, R], [S1, S0, R, R]]
-    strategies_vector_for_input = StrategiesVector(node=nodes[1], in_nodes=nodes[0], strategies=strategies_for_input)
+            strategies_vector_for_input.append(sharding_spec)
     setattr(nodes[1], 'strategies_vector', strategies_vector_for_input)
 
-    strategies_vector = StrategiesVector(node=nodes[2], in_nodes=[
-        nodes[1],
-    ])
-    dot_handler = DotHandler(input_node=nodes[1],
-                             input_index=0,
-                             weight=dict(gm.named_modules())[nodes[2].name].weight,
-                             output_node=nodes[2],
+    # generate dot strategy
+    strategies_vector = StrategiesVector(node=nodes[2])
+    dot_handler = DotHandler(node=nodes[2],
                              device_mesh=device_mesh,
                              strategies_vector=strategies_vector,
                              shape_consistency_manager=shape_consistency_manager)
-    dot_handler.register_strategy_into_strategies_vector()
+    strategies_vector = dot_handler.register_strategy()
 
     # ['S0S1 = S0R x RS1', 'S1S0 = S1R x RS0', 'S0R = S0S1 x S1R', 'S1R = S1S0 x S0R', 'RS1 = RS0 x S0S1', 'RS0 = RS1 x S1S0', 'RS0 = RR x RS0', 'RS1 = RR x RS1', 'RR = RR x RR']
-    strategy_name_list = [strategy.name for strategy in dot_handler.strategies_vector.strategies]
+    strategy_name_list = [strategy.name for strategy in strategies_vector]
 
     # SS = SR x RS
     assert 'S0S1 = S0R x RS1' in strategy_name_list


### PR DESCRIPTION
In this PR, I have refactored the implementation of solver module to integrate with torch fx. Some changes are made in this PR and they will be explained below:

1. Use torch.fx Node to retrieve predecessor and successor nodes

The previous implementation requires us to manually key in the input and output nodes, this can be done automatically by accessing the `_input_nodes` and `users` attributes in the `Node` object.

2. Simplify the APIs

Some APIs are too long and they are simplified here. Some examples include:
- `OpeatorHandler.register_strategy_into_strategies_vector` -> `OpeatorHandler.register_strategy`, and this function now return the strategy vector directly.
- Make `StrategiesVector` a subclass of `list` instead of keep a list as an attribute, so we no longer need to keep redundant attributes like `StrategiesVector.strategies`
- `in_nodes` and `output_nodes` parameters are no longer kept due to 1.

3. OperatorHandler now provides `module_named_parameters` attribute

Instead of passing weight to operator handler, operator handler now can access the parameter internally. This can be generalized to all other handlers which require access to parameters.