### PR TITLE
[autoparallel] added namespace constraints

### DIFF
--- a/colossalai/auto_parallel/solver/conv_handler.py
+++ b/colossalai/auto_parallel/solver/conv_handler.py
@@ -4,6 +4,8 @@ import torch
 from colossalai.auto_parallel.solver.sharding_strategy import ShardingStrategy, StrategiesVector
 from .operator_handler import OperatorHandler
 
+__all__ = ['ConvHandler']
+
 
 class ConvHandler(OperatorHandler):
     """

--- a/colossalai/auto_parallel/solver/dot_handler.py
+++ b/colossalai/auto_parallel/solver/dot_handler.py
@@ -4,6 +4,8 @@ from colossalai.auto_parallel.solver.sharding_strategy import ShardingStrategy, 
 from .operator_handler import OperatorHandler
 from functools import reduce
 
+__all__ = ['DotHandler']
+
 
 class DotHandler(OperatorHandler):
     """

--- a/colossalai/auto_parallel/solver/operator_handler.py
+++ b/colossalai/auto_parallel/solver/operator_handler.py
@@ -1,3 +1,4 @@
+from webbrowser import Opera
 import torch
 import torch.nn as nn
 from abc import ABC, abstractmethod
@@ -8,6 +9,8 @@ from colossalai.tensor.shape_consistency import ShapeConsistencyManager
 from colossalai.tensor.sharding_spec import ShardingSpec
 
 from .sharding_strategy import StrategiesVector
+
+__all__ = ['OperatorHandler']
 
 
 class OperatorHandler(ABC):


### PR DESCRIPTION
Add `__all__` to files in the `auto_parallel` module for namespace standardization.