### PR TITLE
[autoparallel]add backward cost info into strategies

### DIFF
--- a/colossalai/auto_parallel/solver/operator_handler.py
+++ b/colossalai/auto_parallel/solver/operator_handler.py
@@ -81,12 +81,17 @@ class OperatorHandler(ABC):
         '''
         # The resharding_cost of weight is counted due to sharing weight cases.
         resharding_costs = {}
-        for input_node, input_spec in zip(self.predecessor_node, sharding_spec_for_input):
+        for input_node, target_spec in zip(self.predecessor_node, sharding_spec_for_input):
             resharding_costs[input_node] = []
             for strategy in input_node.strategies_vector:
                 input_sharding_spec = strategy.output_sharding_spec
                 assert isinstance(input_sharding_spec, ShardingSpec), f'The input node should NOT be a tuple of tensor.'
-                _, _, resharding_cost = self.shape_consistency_manager.shape_consistency(
-                    input_sharding_spec, input_spec)
+                # compute the resharding cost during forward phase
+                _, _, resharding_cost_forward = self.shape_consistency_manager.shape_consistency(
+                    input_sharding_spec, target_spec)
+                # In backward phase, we should convert grad with target_spec into input_sharding_spec
+                _, _, resharding_cost_backward = self.shape_consistency_manager.shape_consistency(
+                    target_spec, input_sharding_spec)
+                resharding_cost = resharding_cost_forward + resharding_cost_backward
                 resharding_costs[input_node].append(resharding_cost)
         return resharding_costs

--- a/tests/test_auto_parallel/test_conv_handler.py
+++ b/tests/test_auto_parallel/test_conv_handler.py
@@ -82,7 +82,6 @@ def test_conv_handler():
                                strategies_vector=strategies_vector,
                                shape_consistency_manager=shape_consistency_manager)
     conv_handler.register_strategy()
-
     # ['S0S1 = S0R x RS1', 'S1S0 = S1R x RS0', 'S0R = S0R x RR', 'S1R = S1R x RR', 'S0R = S0S1 x S1R', 'S1R = S1S0 x S0R', 'RS1 = RS0 x S0S1', 'RS0 = RS1 x S1S0', 'RR = RS0 x S0R', 'RR = RS1 x S1R', 'RS0 = RR x RS0', 'RS1 = RR x RS1', 'RR = RR x RR', 'S01R = S01R x RR', 'RR = RS01 x S01R']
     strategy_name_list = [strategy.name for strategy in conv_handler.strategies_vector]
 


### PR DESCRIPTION
This PR add backward information into conv strategies, the information including:
1. memory cost: I use a memory pair to store the memory cost, first element of pair is forward memory cost and second one is backward memory cost which is composed with activation grad cost and parameters grad cost.
2. computing cost: compute cost of backward has two parts, first is activation computing cost and second is parameter computing cost.
3. communication cost: In previous, we only count the communication cost during forward. In the PR, the communication cost of backward is counted. Additionally, in some no forward communication cost case, the communication may happen during backward phase.
4. resharding cost: resharding cost will also happen during backward, such as we convert the input sharding spec from [R, S] into [R, R], which means we need to recover it from [R, R] back to [R, S] during backward phase.