### PR TITLE
[hotfix] change namespace for meta_trace.

### DIFF
--- a/colossalai/fx/tracer/_meta_trace.py
+++ b/colossalai/fx/tracer/_meta_trace.py
@@ -20,7 +20,7 @@ def meta_trace(module: torch.nn.Module, *args, **kwargs) -> Graph:
         >>> graph.print_tabular()
     """
     graph = Graph()
-    namespace = _Namespace()
+    namespace = graph._graph_namespace
 
     class MetaProxy(torch.Tensor):
         """


### PR DESCRIPTION
The `namespace` for this tracer should be default as `graph._graph_namespace`, so that variable names are correct in the display.