### PR TITLE
[autoparallel] change the following nodes strategies generation logic

### DIFF
--- a/colossalai/auto_parallel/solver/op_handler/__init__.py
+++ b/colossalai/auto_parallel/solver/op_handler/__init__.py
@@ -4,9 +4,10 @@ from .conv_handler import ConvHandler
 from .batch_norm_handler import BatchNormHandler
 from .reshape_handler import ReshapeHandler
 from .bcast_op_handler import BcastOpHandler
+from .embedding_handler import EmbeddingHandler
 from .unary_elementwise_handler import UnaryElementwiseHandler
 
 __all__ = [
     'OperatorHandler', 'DotHandler', 'ConvHandler', 'BatchNormHandler', 'ReshapeHandler', 'BcastOpHandler',
-    'UnaryElementwiseHandler'
+    'UnaryElementwiseHandler', 'EmbeddingHandler'
 ]

--- a/tests/test_auto_parallel/test_strategies_constructor.py
+++ b/tests/test_auto_parallel/test_strategies_constructor.py
@@ -59,7 +59,7 @@ def test_strategies_constructor():
     assert strategies_constructor.leaf_strategies[0][0].name == 'Replica Placeholder'
 
     # Second node is mul which is a element-wise node, therefore the output sharding spec is same as input sharding spec.
-    assert strategies_constructor.leaf_strategies[1][0].name == '[R, R, R, R] -> [R, R, R, R]'
+    assert strategies_constructor.leaf_strategies[1][0].name == '[R, R, R, R] -> [R, R, R, R]_0'
 
     # Third node is conv.
     conv_check_list = deepcopy(CONV_STRATEGIES_LIST)
@@ -79,7 +79,7 @@ def test_strategies_constructor():
 
     # Second node is mul which is a element-wise node, therefore the output sharding spec is same as input sharding spec.
     mul = nodes[1]
-    assert strategies_constructor.strategy_map[mul][0].name == '[R, R, R, R] -> [R, R, R, R]'
+    assert strategies_constructor.strategy_map[mul][0].name == '[R, R, R, R] -> [R, R, R, R]_0'
 
     # Third node is conv.
     conv = nodes[2]


### PR DESCRIPTION
This PR changes the following nodes(nodes will be merged into other nodes) strategies generation logic, new version handlers for following nodes will **keep the duplicated strategies**. **To avoid the duplicated  check in StrategiesConstructor,** handler will **attatch the index of input strategy on new strategy name.** 

**This behavior will not increase the seaching space**, because no matter how many strategies generated by handler, **the following nodes will be merged and solver won't create a new variable for it.**