### PR TITLE
[autoparallel] runtime_backward_apply

### DIFF
--- a/colossalai/tensor/shape_consistency.py
+++ b/colossalai/tensor/shape_consistency.py
@@ -498,3 +498,11 @@ class ShapeConsistencyManager(metaclass=SingletonMeta):
         for comm_spec in comm_action_sequence:
             comm_spec.covert_spec_to_action(tensor_with_sharding_spec)
         tensor_with_sharding_spec.sharding_spec = target_spec
+        return tensor_with_sharding_spec
+
+    def apply_for_autoparallel_runtime(self, tensor, source_spec, target_spec):
+        _, comm_action_sequence, _ = self.shape_consistency(source_spec, target_spec)
+        for comm_spec in comm_action_sequence:
+            comm_spec.covert_spec_to_action(tensor)
+        tensor.sharding_spec = target_spec
+        return tensor


### PR DESCRIPTION
### What does this PR do
1. In new version apply function, we do not have to set the sharding_spec attribute to tensor. Therefore, the getitem and setattr nodes disappear in new version graph.
2. **Fix a bug caused by mechanic of leaf nodes backward,** which leads to backward  of communicaion operation in leaf node not called during runtime.