### PR TITLE
[workflow] handled the git directory ownership error

### DIFF
--- a/.github/workflows/release_bdist.yml
+++ b/.github/workflows/release_bdist.yml
@@ -65,6 +65,7 @@ jobs:
         run: |
           cp -r ./.github/workflows/scripts/* ./
           ln -s /github/home/pip_wheels ./pip_wheels
+          git config --global --add safe.directory /__w/ColossalAI/ColossalAI
           git checkout $git_ref
           wget https://github.com/NVIDIA/cub/archive/refs/tags/1.8.0.zip
           unzip 1.8.0.zip


### PR DESCRIPTION
## What is the problem?

In newer-version git (> 2.25), the security feature is enhanced such that it will check the ownership of the current git repo. If the directory is not completely owned by the current user, the user cannot do anything e.g. `git checkout` . Therefore, to be safe, we need to add the current directory to the safe directory list.

## What does this PR do?

This PR modified the script to build the binary wheels such that it will not raise ownership error when checking out to a different ref.

