### PR TITLE
[autoparallel] fixed shape consistency backward not invoked error

### DIFF
--- a/colossalai/fx/passes/experimental/adding_shape_consistency_pass_v2.py
+++ b/colossalai/fx/passes/experimental/adding_shape_consistency_pass_v2.py
@@ -16,23 +16,10 @@ from colossalai.tensor.sharding_spec import ShardingSpec, _DimSpec
 shape_consistency_manager = ShapeConsistencyManager()
 
 
-class ConsistencyApply(torch.autograd.Function):
-
-    @staticmethod
-    def forward(ctx, node, origin_dict, input_dict, node_index, user_node_index):
-        ctx.origin_sharding_spec = origin_dict[node_index]
-        ctx.target_sharding_spec = input_dict[node_index][user_node_index]
-        return shape_consistency_manager.apply_for_autoparallel_runtime(node, ctx.origin_sharding_spec,
-                                                                        ctx.target_sharding_spec)
-
-    @staticmethod
-    def backward(ctx, node_grad):
-        return shape_consistency_manager.apply_for_autoparallel_runtime(
-            node_grad, ctx.target_sharding_spec, ctx.origin_sharding_spec), None, None, None, None
-
-
 def runtime_apply_for_leaf_node(node, origin_dict, input_dict, node_index, user_node_index):
-    return ConsistencyApply.apply(node, origin_dict, input_dict, node_index, user_node_index)
+    origin_sharding_spec = origin_dict[node_index]
+    target_sharding_spec = input_dict[node_index][user_node_index]
+    return shape_consistency_manager.apply_for_autoparallel_runtime(node, origin_sharding_spec, target_sharding_spec)
 
 
 def runtime_apply(node, origin_dict, input_dict, node_index, user_node_index):

--- a/colossalai/tensor/comm_spec.py
+++ b/colossalai/tensor/comm_spec.py
@@ -1,8 +1,9 @@
-import torch
-from enum import Enum
-import torch.distributed as dist
-from functools import reduce
 import operator
+from enum import Enum
+from functools import reduce
+
+import torch
+import torch.distributed as dist
 from torch.distributed import ReduceOp
 
 __all__ = [
@@ -238,7 +239,7 @@ class CommSpec:
     1. Compute the communication cost which will be used in auto parallel solver.
     2. Convert the communication spec to real action which will be used in runtime.
     It contains comm_pattern to determine the
-    communication method, sharding_spec to determine the communication size, gather_dim and shard_dim 
+    communication method, sharding_spec to determine the communication size, gather_dim and shard_dim
     to determine the buffer shape, and logical_process_axis
 
     Argument:
@@ -296,7 +297,7 @@ class CommSpec:
         '''
         For all_gather, all2all, and all_reduce operation, the formula provided in DeviceMesh with alpha-beta model is used to
         compute the communication cost.
-        For shard operation, it is an on-chip operation, so the communication cost is zero. 
+        For shard operation, it is an on-chip operation, so the communication cost is zero.
         '''
         comm_size = reduce(operator.mul, self.sharding_spec.get_sharded_shape_per_device(), 1)
         cost_dict = {}
@@ -344,9 +345,10 @@ class CommSpec:
             tensor(torch.Tensor): Tensor stored in each device, which could be different in different ranks.
         '''
         if self.comm_pattern in pattern_to_func_dict:
-            tensor.data = pattern_to_func_dict[self.comm_pattern](tensor, self)
+            tensor = pattern_to_func_dict[self.comm_pattern](tensor, self)
         else:
-            tensor.data = tensor
+            tensor = tensor
+        return tensor
 
 
 pattern_to_func_dict = {

--- a/colossalai/tensor/shape_consistency.py
+++ b/colossalai/tensor/shape_consistency.py
@@ -518,6 +518,6 @@ class ShapeConsistencyManager(metaclass=SingletonMeta):
     def apply_for_autoparallel_runtime(self, tensor, source_spec, target_spec):
         _, comm_action_sequence, _ = self.shape_consistency(source_spec, target_spec)
         for comm_spec in comm_action_sequence:
-            comm_spec.covert_spec_to_action(tensor)
+            tensor = comm_spec.covert_spec_to_action(tensor)
         tensor.sharding_spec = target_spec
         return tensor

--- a/tests/test_auto_parallel/test_tensor_shard/test_resnet_block_runtime.py
+++ b/tests/test_auto_parallel/test_tensor_shard/test_resnet_block_runtime.py
@@ -1,28 +1,31 @@
+from copy import deepcopy
 from functools import partial
+
 import pytest
 import torch
 import torch.multiprocessing as mp
-from torch.fx import GraphModule
 import torch.nn as nn
-import pytest
-from colossalai import device
-from colossalai.initialize import launch
-from colossalai.utils import free_port
-from colossalai.testing import rerun_if_address_is_in_use
-from colossalai.logging import disable_existing_loggers
-from colossalai.auto_parallel.tensor_shard.solver.graph_analysis import GraphAnalyser
-from colossalai.fx.tracer.tracer import ColoTracer
-from colossalai.fx.passes.experimental.adding_shape_consistency_pass_v2 import shape_consistency_pass, solution_annotatation_pass
-from colossalai.auto_parallel.tensor_shard.solver.options import SolverOptions
-from colossalai.device.device_mesh import DeviceMesh
-from colossalai.auto_parallel.tensor_shard.solver.strategies_constructor import StrategiesConstructor
-from colossalai.auto_parallel.tensor_shard.solver.cost_graph import CostGraph
-from copy import deepcopy
-from colossalai.auto_parallel.tensor_shard.solver.solver import Solver
+from torch.fx import GraphModule
 from torchvision.models import resnet34, resnet50
+
+from colossalai import device
 from colossalai.auto_parallel.tensor_shard.constants import *
-from colossalai.testing import assert_close_loose, assert_close
+from colossalai.auto_parallel.tensor_shard.solver.cost_graph import CostGraph
+from colossalai.auto_parallel.tensor_shard.solver.graph_analysis import GraphAnalyser
+from colossalai.auto_parallel.tensor_shard.solver.options import SolverOptions
+from colossalai.auto_parallel.tensor_shard.solver.solver import Solver
+from colossalai.auto_parallel.tensor_shard.solver.strategies_constructor import StrategiesConstructor
+from colossalai.device.device_mesh import DeviceMesh
+from colossalai.fx.passes.experimental.adding_shape_consistency_pass_v2 import (
+    shape_consistency_pass,
+    solution_annotatation_pass,
+)
+from colossalai.fx.tracer.tracer import ColoTracer
+from colossalai.initialize import launch
+from colossalai.logging import disable_existing_loggers
+from colossalai.testing import assert_close, assert_close_loose, rerun_if_address_is_in_use
 from colossalai.testing.pytest_wrapper import run_on_environment_flag
+from colossalai.utils import free_port
 
 seed = 128
 cudnn_benchmark = False

--- a/tests/test_auto_parallel/test_tensor_shard/test_shape_consistency_pass.py
+++ b/tests/test_auto_parallel/test_tensor_shard/test_shape_consistency_pass.py
@@ -6,11 +6,18 @@ import torch.multiprocessing as mp
 import torch.nn as nn
 from torch.fx import GraphModule
 
-from colossalai.auto_parallel.tensor_shard.solver import (CostGraph, GraphAnalyser, Solver, SolverOptions,
-                                                          StrategiesConstructor)
+from colossalai.auto_parallel.tensor_shard.solver import (
+    CostGraph,
+    GraphAnalyser,
+    Solver,
+    SolverOptions,
+    StrategiesConstructor,
+)
 from colossalai.device.device_mesh import DeviceMesh
-from colossalai.fx.passes.experimental.adding_shape_consistency_pass_v2 import (shape_consistency_pass,
-                                                                                solution_annotatation_pass)
+from colossalai.fx.passes.experimental.adding_shape_consistency_pass_v2 import (
+    shape_consistency_pass,
+    solution_annotatation_pass,
+)
 from colossalai.fx.tracer.tracer import ColoTracer
 from colossalai.initialize import launch
 from colossalai.logging import disable_existing_loggers


### PR DESCRIPTION
## What is the problem?

In the previous implementation, we have to define a nested autograd function in order to apply the sharding spec conversion during runtime. This is because we implemented the logic as shown below. Using the `.data` attribute will make it in-place and not triggering any autograd function.

```
tensor.data = some_spec_convert_function(tensor)
```

## What does this PR do?

This PR fixed this bug and now we don't have to use a nested autograd function, reducing code complexity.

## Future Work

Some logic needs to be tidied up as they currently lead to test errors.

1. How to shard a module parameter?
2. How to convert a sharded tensor to its global view? (this is useful when we want to compare the sharded output and expected output)

