### PR TITLE
[autoparallel] recovered skipped test cases

### DIFF
--- a/tests/test_auto_parallel/test_tensor_shard/test_node_handler/test_getitem_handler.py
+++ b/tests/test_auto_parallel/test_tensor_shard/test_node_handler/test_getitem_handler.py
@@ -21,7 +21,6 @@ class GetItemModel(nn.Module):
         return x
 
 
-@run_on_environment_flag(name='AUTO_PARALLEL')
 def test_getitem_function_handler():
     model = GetItemModel()
     tracer = ColoTracer()

--- a/tests/test_auto_parallel/test_tensor_shard/test_node_handler/test_reshape_handler.py
+++ b/tests/test_auto_parallel/test_tensor_shard/test_node_handler/test_reshape_handler.py
@@ -20,7 +20,6 @@ class ReshapeModel(nn.Module):
         return reshape_node
 
 
-@run_on_environment_flag(name='AUTO_PARALLEL')
 def test_reshape_handler():
     model = ReshapeModel()
     tracer = ColoTracer()

--- a/tests/test_auto_parallel/test_tensor_shard/test_node_handler/test_unary_element_wise_handler.py
+++ b/tests/test_auto_parallel/test_tensor_shard/test_node_handler/test_unary_element_wise_handler.py
@@ -22,7 +22,6 @@ class ReLuModel(nn.Module):
         return relu_node
 
 
-@run_on_environment_flag(name='AUTO_PARALLEL')
 def test_elementwise_handler():
     model = ReLuModel()
     tracer = ColoTracer()


### PR DESCRIPTION
## What does this PR do?

This test recovered the skipped test. These tests were skipped previously due to the erroneous conv handler output. As the #1747 PR fixed the conv handler, these tests work fine now.