### PR TITLE
[autoparallel] shard param and buffer as expected

### DIFF
--- a/colossalai/tensor/comm_spec.py
+++ b/colossalai/tensor/comm_spec.py
@@ -345,9 +345,9 @@ class CommSpec:
             tensor(torch.Tensor): Tensor stored in each device, which could be different in different ranks.
         '''
         if self.comm_pattern in pattern_to_func_dict:
-            tensor.data = pattern_to_func_dict[self.comm_pattern](tensor, self)
+            tensor = pattern_to_func_dict[self.comm_pattern](tensor, self)
         else:
-            tensor.data = tensor
+            tensor = tensor
         return tensor
 
 

--- a/colossalai/tensor/shape_consistency.py
+++ b/colossalai/tensor/shape_consistency.py
@@ -511,13 +511,13 @@ class ShapeConsistencyManager(metaclass=SingletonMeta):
         '''
         _, comm_action_sequence, _ = self.shape_consistency(tensor_with_sharding_spec.sharding_spec, target_spec)
         for comm_spec in comm_action_sequence:
-            comm_spec.covert_spec_to_action(tensor_with_sharding_spec)
+            tensor_with_sharding_spec = comm_spec.covert_spec_to_action(tensor_with_sharding_spec)
         tensor_with_sharding_spec.sharding_spec = target_spec
         return tensor_with_sharding_spec
 
     def apply_for_autoparallel_runtime(self, tensor, source_spec, target_spec):
         _, comm_action_sequence, _ = self.shape_consistency(source_spec, target_spec)
         for comm_spec in comm_action_sequence:
-            comm_spec.covert_spec_to_action(tensor)
+            tensor = comm_spec.covert_spec_to_action(tensor)
         tensor.sharding_spec = target_spec
         return tensor

--- a/tests/test_tensor/test_comm_spec_apply.py
+++ b/tests/test_tensor/test_comm_spec_apply.py
@@ -1,17 +1,19 @@
-import torch
 from functools import partial
+
 import pytest
+import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 from torch.distributed import ReduceOp
+
 from colossalai.core import global_context as gpc
-from colossalai.initialize import launch
-from colossalai.utils import free_port
-from colossalai.testing import rerun_if_address_is_in_use
 from colossalai.device.device_mesh import DeviceMesh
-from colossalai.tensor.shape_consistency import CommSpec, CollectiveCommPattern
+from colossalai.initialize import launch
 from colossalai.logging import disable_existing_loggers
+from colossalai.tensor.shape_consistency import CollectiveCommPattern, CommSpec
 from colossalai.tensor.sharding_spec import ShardingSpec
+from colossalai.testing import rerun_if_address_is_in_use
+from colossalai.utils import free_port
 
 
 def check_all_gather(device_mesh, rank):
@@ -37,7 +39,7 @@ def check_all_gather(device_mesh, rank):
                          sharding_spec,
                          gather_dim=1,
                          logical_process_axis=1)
-    comm_spec.covert_spec_to_action(sharded_tensor_to_comm)
+    sharded_tensor_to_comm = sharded_tensor_to_comm = comm_spec.covert_spec_to_action(sharded_tensor_to_comm)
 
     assert sharded_tensor_to_comm.equal(tensor_to_check)
 
@@ -60,7 +62,7 @@ def check_shard(device_mesh, rank):
 
     # CommSpec:(comm_pattern:shard, shard_dim:1, logical_process_axis:1)
     comm_spec = CommSpec(CollectiveCommPattern.SPLIT_FWD_GATHER_BWD, sharding_spec, shard_dim=1, logical_process_axis=1)
-    comm_spec.covert_spec_to_action(tensor_to_shard)
+    tensor_to_shard = comm_spec.covert_spec_to_action(tensor_to_shard)
 
     if rank in (0, 2):
         assert tensor_to_shard.equal(sharded_tensor_to_comm_0)
@@ -110,7 +112,7 @@ def check_all_to_all(device_mesh, rank):
                          gather_dim=0,
                          shard_dim=1,
                          logical_process_axis=0)
-    comm_spec.covert_spec_to_action(tensor_to_comm)
+    tensor_to_comm = comm_spec.covert_spec_to_action(tensor_to_comm)
 
     assert tensor_to_comm.equal(tensor_to_check)
 
@@ -137,7 +139,7 @@ def check_all_reduce_fwd(device_mesh, rank):
     sharding_spec = ShardingSpec(device_mesh, tensor_to_comm.shape, dim_partition_dict=dim_partition_dict)
 
     comm_spec = CommSpec(CollectiveCommPattern.ALLREDUCE_FWD_IDENTITY_BWD, sharding_spec, logical_process_axis=0)
-    comm_spec.covert_spec_to_action(tensor_to_comm)
+    tensor_to_comm = comm_spec.covert_spec_to_action(tensor_to_comm)
 
     assert tensor_to_comm.equal(tensor_to_check)
 
@@ -155,7 +157,7 @@ def check_all_reduce_bwd(device_mesh, rank):
     sharding_spec = ShardingSpec(device_mesh, tensor_to_comm.shape, dim_partition_dict=dim_partition_dict)
 
     comm_spec = CommSpec(CollectiveCommPattern.IDENTITY_FWD_ALLREDUCE_BWD, sharding_spec, logical_process_axis=0)
-    comm_spec.covert_spec_to_action(tensor_to_comm)
+    tensor_to_comm = comm_spec.covert_spec_to_action(tensor_to_comm)
 
     assert tensor_to_comm.equal(tensor_to_check)
 
@@ -178,7 +180,7 @@ def check_all_reduce_in_flatten_device_mesh(device_mesh, rank):
 
     # CommSpec:(comm_pattern:all_reduce, logical_process_axis:[0, 1])
     comm_spec = CommSpec(CollectiveCommPattern.ALLREDUCE_FWD_IDENTITY_BWD, sharding_spec, logical_process_axis=[0, 1])
-    comm_spec.covert_spec_to_action(tensor_to_comm)
+    tensor_to_comm = comm_spec.covert_spec_to_action(tensor_to_comm)
 
     assert tensor_to_comm.equal(tensor_to_check)
 

--- a/tests/test_tensor/test_shape_consistency_apply.py
+++ b/tests/test_tensor/test_shape_consistency_apply.py
@@ -1,15 +1,16 @@
 from functools import partial
+
 import pytest
 import torch
 import torch.multiprocessing as mp
 
-from colossalai.tensor.sharding_spec import ShardingSpec
 from colossalai.device.device_mesh import DeviceMesh
 from colossalai.initialize import launch
-from colossalai.utils import free_port
-from colossalai.testing import rerun_if_address_is_in_use
 from colossalai.logging import disable_existing_loggers
-from colossalai.tensor.shape_consistency import ShapeConsistencyManager, CollectiveCommPattern
+from colossalai.tensor.shape_consistency import CollectiveCommPattern, ShapeConsistencyManager
+from colossalai.tensor.sharding_spec import ShardingSpec
+from colossalai.testing import rerun_if_address_is_in_use
+from colossalai.utils import free_port
 
 
 def check_apply(rank, world_size, port):
@@ -63,7 +64,7 @@ def check_apply(rank, world_size, port):
         tensor_to_check = torch.tensor([[1], [1], [3], [3]], dtype=tensor_to_comm.dtype).cuda()
 
     tensor_to_comm.sharding_spec = sharding_spec_source
-    shape_consistency_manager.apply(tensor_to_comm, sharding_spec_target)
+    tensor_to_comm = shape_consistency_manager.apply(tensor_to_comm, sharding_spec_target)
     assert tensor_to_comm.equal(tensor_to_check)
     assert str(tensor_to_comm.sharding_spec.sharding_sequence) == str(sharding_spec_target.sharding_sequence)
 


### PR DESCRIPTION
### what does this PR do
1. as PR(https://github.com/hpcaitech/ColossalAI/pull/1745) mentioned, the previous implementation may lead to autograd backward function not invoked, this problem has been solved in this PR.
2. Update the solution_annotation_pass to make sure Parameters and Buffers are shard as expected.
3. Refactor the runtime apply function and remove the previous autograd function.