### PR TITLE
[CI] downgrade requirements fbgemm.

### DIFF
--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,11 +1,12 @@
 diffusers
+fbgemm-gpu==0.2.0
 pytest
 torchvision
 transformers
 timm
 titans
 torchaudio
-torchrec
+torchrec==0.2.0
 contexttimer
 einops
 triton==2.0.0.dev20221011


### PR DESCRIPTION
Downgrade requirements for `fbgemm-gpu` because of errors in latest version.
https://github.com/pytorch/FBGEMM/issues/1401