### PR TITLE
[autoparallel] fix linear logical convert issue

### DIFF
--- a/colossalai/auto_parallel/passes/runtime_preparation_pass.py
+++ b/colossalai/auto_parallel/passes/runtime_preparation_pass.py
@@ -52,7 +52,6 @@ def _solution_annotatation(gm: torch.fx.GraphModule, solution: List[int]):
         if node.op == 'get_attr':
             assert len(target_sharding_specs) == 1, f'sharing weight is not supported in current version.'
             new_sharding_spec = target_sharding_specs[0]
-            user_node = node.strategies_vector.successor_nodes[0]
             user_strategy = node.strategies_vector.successor_nodes[0].best_strategy
             op_data_in_user = user_strategy.get_op_data_by_name(str(node))
             origin_node_sharding_spec_dict[index] = new_sharding_spec

--- a/colossalai/auto_parallel/tensor_shard/solver/solver.py
+++ b/colossalai/auto_parallel/tensor_shard/solver/solver.py
@@ -32,7 +32,8 @@ class Solver:
                  memory_budget: float = -1.0,
                  solution_numbers: int = 1,
                  forward_only: bool = False,
-                 memory_increasing_coefficient: float = 1.3):
+                 memory_increasing_coefficient: float = 1.3,
+                 verbose=True):
         '''
         Solver class will integrate information provided by the components and use ILP solver to find a possible optimal strategies combination for target computing graph.
         Argument:
@@ -64,6 +65,7 @@ class Solver:
         self.last_s_val = None
         # The last objective value of the best ILP solution.
         self.last_objective = None
+        self.verbose = verbose
 
     def _recover_merged_node_strategy(self):
         '''
@@ -177,7 +179,7 @@ class Solver:
         # omit initial value for nodes
         s_init_np = None
 
-        return node_nums, memory_budget, strategies_len, following_nodes, edge_pairs, alias_set, liveness_set, compute_costs, communication_costs, memory_costs, resharding_costs, alias_convert_costs, s_init_np
+        return node_nums, memory_budget, strategies_len, following_nodes, edge_pairs, alias_set, liveness_set, compute_costs, communication_costs, memory_costs, resharding_costs, alias_convert_costs, s_init_np, self.verbose
 
     def _call_solver_serialized_args(self,
                                      node_nums,
@@ -192,7 +194,8 @@ class Solver:
                                      memory_costs,
                                      resharding_costs,
                                      alias_convert_costs,
-                                     s_init_np=None):
+                                     s_init_np=None,
+                                     verbose=True):
         """
         Call the solver with serialized arguments.
         """
@@ -406,8 +409,6 @@ class Solver:
         #         for col in range(len(s[j])):
         #             if v[idx][row * C + col] > 0.5:
         #                 prob += s[i][row] + s[j][col] <= 1
-
-        verbose = True
 
         msg = verbose
         time_limit = 600

--- a/tests/test_auto_parallel/test_tensor_shard/test_node_handler/utils.py
+++ b/tests/test_auto_parallel/test_tensor_shard/test_node_handler/utils.py
@@ -95,7 +95,7 @@ def numerical_test_for_node_strategy(model: torch.nn.Module,
             cost_graph = CostGraph(strategies_constructor.leaf_strategies)
             cost_graph.simplify_graph()
             graph_analyser = GraphAnalyser(gm)
-            solver = Solver(gm.graph, strategies_constructor, cost_graph, graph_analyser)
+            solver = Solver(gm.graph, strategies_constructor, cost_graph, graph_analyser, verbose=False)
             ret = solver.call_solver_serialized_args()
             solution = list(ret[0])
         gm, sharding_spec_dict, origin_spec_dict, comm_actions_dict = runtime_preparation_pass(


### PR DESCRIPTION
This PR converts the logical last dim of linear input and output to physical last dim.
For example:
    The input logical tensor for linear node is a 2d tensor. So if the last dim is sharded, the dim_partition_dict is {1: [0]}
    However, if input is a 4d tensor physically, we should modify the dim_partition_dict to {3: [0]}