### PR TITLE
[autoparallel] mix gather

### DIFF
--- a/colossalai/tensor/comm_spec.py
+++ b/colossalai/tensor/comm_spec.py
@@ -79,6 +79,34 @@ def _all_reduce(tensor, comm_spec, async_op=False):
             return tensor
 
 
+def _mix_gather(tensor, comm_spec):
+    '''
+    Implement mix gather operation on device mesh based on information provided by comm_spec.
+    '''
+    total_slices = reduce(operator.mul, comm_spec.device_mesh.mesh_shape, 1)
+    tensor_list = [torch.zeros(tensor.shape, dtype=tensor.dtype, device=tensor.device) for _ in range(total_slices)]
+    leading_group_dim = comm_spec.logical_process_axes[0]
+    process_group = comm_spec.device_mesh.process_groups_dict[leading_group_dim]
+    dist.all_gather(tensor_list, tensor, group=process_group)
+
+    if comm_spec.logical_process_axes[0] == comm_spec.logical_process_axes[1]:
+        output = torch.cat(tuple(tensor_list), comm_spec.gather_dim).contiguous()
+    else:
+        mesh_shape = comm_spec.device_mesh.mesh_shape
+        cat_slice = [mesh_shape[comm_spec.logical_process_axes[0]], mesh_shape[comm_spec.logical_process_axes[1]]]
+        tmp_tensor_shape = tensor.shape
+        tmp_tensor_shape[comm_spec.gather_dim[0]] *= tensor.shape[leading_group_dim]
+        tmp_tensor_list = [
+            torch.zeros(tmp_tensor_shape, dtype=tensor.dtype, device=tensor.device) for _ in range(cat_slice[1])
+        ]
+        for i in range(cat_slice[1]):
+            tmp_tensor_list[i] = torch.cat(tuple(tensor_list[i * cat_slice[0]:(i + 1) * cat_slice[0]]),
+                                           comm_spec.gather_dim[0]).contiguous()
+        output = torch.cat(tuple(tmp_tensor_list), comm_spec.gather_dim[1]).contiguous()
+
+    return output
+
+
 class _ReduceGrad(torch.autograd.Function):
     """
     A customized communication operation which forward is an identity operation,
@@ -204,6 +232,17 @@ class _AllToAll(torch.autograd.Function):
         return _all_to_all(grad_outputs, ctx.comm_spec), None
 
 
+class _MixGather(torch.autograd.Function):
+
+    @staticmethod
+    def symbolic(graph, input_):
+        return _mix_gather(input_)
+
+    @staticmethod
+    def forward(ctx, input_, commspec):
+        output = _mix_gather(input_, comm_spec)
+
+
 def reduce_grad(input_, comm_spec):
     return _ReduceGrad.apply(input_, comm_spec)
 
@@ -230,6 +269,7 @@ class CollectiveCommPattern(Enum):
     SPLIT_FWD_GATHER_BWD = 'split_fwd_gather_bwd'
     ALLREDUCE_FWD_IDENTITY_BWD = 'all_reduce_fwd_identity_bwd'
     IDENTITY_FWD_ALLREDUCE_BWD = 'identity_fwd_all_reduce_bwd'
+    MIXGATHER_FWD_SPLIT_BWD = "mixgather_fwd_split_bwd"
 
 
 class CommSpec:
@@ -255,18 +295,22 @@ class CommSpec:
                  gather_dim=None,
                  shard_dim=None,
                  logical_process_axis=None,
-                 forward_only=False):
+                 forward_only=False,
+                 mix_gather=False):
         self.comm_pattern = comm_pattern
         self.sharding_spec = sharding_spec
         self.gather_dim = gather_dim
         self.shard_dim = shard_dim
         self.logical_process_axis = logical_process_axis
         self.forward_only = forward_only
-        if isinstance(self.logical_process_axis, list):
+        if isinstance(self.logical_process_axis, list) and not mix_gather:
             self.device_mesh = self.sharding_spec.device_mesh.flatten_device_mesh
             self.logical_process_axis = 0
         else:
             self.device_mesh = self.sharding_spec.device_mesh
+        if isinstance(self.logical_process_axis, list) and mix_gather:
+            self.device_mesh = self.sharding_spec.device_mesh.flatten_device_meshes
+            self.logical_process_axes = logical_process_axis
 
     def __repr__(self):
         res_list = ["CommSpec:("]

--- a/colossalai/tensor/comm_spec.py
+++ b/colossalai/tensor/comm_spec.py
@@ -89,8 +89,8 @@ def _mix_gather(tensor, comm_spec):
     ShardingSpec => gather_dim, logical_process_axes
     S0S1 => [b, f], (1, 0)
     S1S0 => [b, f], (0, 1)
-    S01R => [f], (0, 0)
-    RS01 => [b], (0, 0)
+    S01R => [f], (1, 1)
+    RS01 => [b], (1, 1)
     Example:
     mesh_shape = (2,4)
             # [[0, 1, 2, 3],
@@ -117,11 +117,11 @@ def _mix_gather(tensor, comm_spec):
     tmp_tensor_list[1] = torch.cat(((1,0),(1,1)), dim=b)
     tmp_tensor_list[2] = torch.cat(((2,0),(2,1)), dim=b)
     tmp_tensor_list[3] = torch.cat(((3,0),(3,1)), dim=b)
-    S01R:
+    S10R:
     leading_group_dim = 0
     process_group = "[0, 4, 1, 5, 2, 6, 3, 7]"
     tensor_list = [(0,0),(1,0),(2,0),(3,0),(4,0),(5,0),(6,0),(7,0)]
-    S10R:
+    S01R:
     leading_group_dim = 1
     process_group = "[0, 1, 2, 3, 4, 5, 6, 7]"
     tensor_list = [(0,0),(1,0),(2,0),(3,0),(4,0),(5,0),(6,0),(7,0)]

--- a/colossalai/tensor/comm_spec.py
+++ b/colossalai/tensor/comm_spec.py
@@ -82,6 +82,9 @@ def _all_reduce(tensor, comm_spec, async_op=False):
 def _mix_gather(tensor, comm_spec):
     '''
     Implement mix gather operation on device mesh based on information provided by comm_spec.
+    Mix gather is the all-gather operation on all devices in the device_mesh(FlattenDeviceMesh) of the comm_spec. It is
+    different from _all_gather because _mix_gather does all-gather in two dimensions of device mesh, while _all_gather
+    only does all-gather in one dimension.
     Assume index of f and b target pairs are 'f' and 'b'
     ShardingSpec => gather_dim, logical_process_axes
     S0S1 => [b, f], (1, 0)
@@ -150,6 +153,8 @@ def _mix_gather(tensor, comm_spec):
 def _mix_split(tensor, comm_spec):
     '''
     Implement mix split operation. Mix split is only called for the backward of mix gather (Use ctx to keep consistent)
+    Mix split shards the tensor on device mesh based on information provided by comm_spec. It is different from split
+    because _mix_split shards the tensor in two dimensions of device mesh, while _split only shards in one dimension.
     Assume index of f and b target pairs are 'f' and 'b'
     S0S1 => [b, f], (1, 0)
     S1S0 => [b, f], (0, 1)

--- a/colossalai/tensor/comm_spec.py
+++ b/colossalai/tensor/comm_spec.py
@@ -175,7 +175,16 @@ def _mix_split(tensor, comm_spec):
     mesh_shape = [2,4]
     rank_slice = [4,2]
     length = [shape[b] // 4, shape[f] // 2]
-    start = [0,0], [1 * shape[b] // 4, 0], [2 * shape[b] // 4, 0], [3 * shape[b] // 4, 0], [0, 1 * shape[b] // 2], [1 * shape[b] // 4, 1 * shape[b] // 2], [2 * shape[b] // 4, 1 * shape[b] // 2], [3 * shape[b] // 4, 1 * shape[b] // 2]
+    start = [0, 0], [0, 1 * shape[b] // 4], [0, 2 * shape[b] // 4], [0, 3 * shape[b] // 4],
+            [1 * shape[f] // 2, 0], [1 * shape[f] // 2, 1 * shape[b] // 4], [1 * shape[f] // 2, 2 * shape[b] // 4], [1 * shape[f] // 2, 3 * shape[b] // 4] # In physical_id
+    S1S0:
+    process_group = "[0, 4, 1, 5, 2, 6, 3, 7]"
+    dim = [b, f]
+    tensor_shape = [shape[b], shape[f]]
+    rank_slice = [2,4]
+    length = [shape[b] // 2, shape[f] // 4]
+    start = [0, 0], [shape[f] // 4, 0], [2 * shape[f] // 4, 0], [3 * shape[f] // 4, 0]
+            [0, shape[b] // 2], [shape[f] // 4, shape[b] // 2], [2 * shape[f] // 4, shape[b] // 2], [3 * shape[f] // 4, shape[b] // 2]
     '''
     rank = dist.get_rank()
     if comm_spec.logical_process_axes[0] == comm_spec.logical_process_axes[1]:

--- a/colossalai/tensor/utils.py
+++ b/colossalai/tensor/utils.py
@@ -90,6 +90,25 @@ def shard_simulator(target_pair, legal_sharding_dims):
     return shard_list_list
 
 
+def mix_gather_simulator(f_target_pair, b_target_pair):
+    '''
+    Assume index of f and b target pairs are 'f' and 'b'
+    S0S1 => [b, f], (1, 0)
+    S1S0 => [b, f], (0, 1)
+    S01R => [f], (0, 0)
+    RS01 => [b], (0, 0)
+    '''
+    if f_target_pair[1] and b_target_pair[1]:
+        leading_dim = b_target_pair[1] > f_target_pair[1]
+        return (b_target_pair[0], f_target_pair[1]), (leading_dim, leading_dim ^ 1)
+    if f_target_pair[1]:
+        leading_dim = f_target_pair[1][0] > f_target_pair[1][1]
+        return (f_target_pair[0],), (leading_dim, leading_dim)
+    if b_target_pair[1]:
+        leading_dim = b_target_pair[1][0] > b_target_pair[1][1]
+        return (b_target_pair[0],), (leading_dim, leading_dim)
+
+
 # The function is credited to PyTorch Team
 def named_params_with_colotensor(
     module: nn.Module,

--- a/colossalai/tensor/utils.py
+++ b/colossalai/tensor/utils.py
@@ -95,19 +95,21 @@ def mix_gather_simulator(f_target_pair, b_target_pair):
     Assume index of f and b target pairs are 'f' and 'b'
     S0S1 => Input: (f, [0]), (b, [1]) Output: [b, f], (1, 0)
     S1S0 => Input: (f, [1]), (b, [0]) Output: [b, f], (0, 1)
-    S01R => Input: (f, [0, 1]), (b, []) Output: [f], (0, 0)
-    RS01 => Input: (f, []), (b, [0, 1]) Output: [b], (0, 0)
+    S01R => Input: (f, [0, 1]), (b, []) Output: [f], (1, 1)
+    RS01 => Input: (f, []), (b, [0, 1]) Output: [b], (1, 1)
+    S10R => Input: (f, [0, 1]), (b, []) Output: [f], (0, 0)
+    RS10 => Input: (f, []), (b, [0, 1]) Output: [b], (0, 0)
     '''
     if f_target_pair[1] and b_target_pair[1]:
         leading_dim = b_target_pair[1] > f_target_pair[1]
         return [b_target_pair[0], f_target_pair[0]], [int(leading_dim), int(leading_dim ^ 1)]
     if f_target_pair[1]:
-        leading_dim = f_target_pair[1][0] > f_target_pair[1][1]
+        leading_dim = f_target_pair[1][0] < f_target_pair[1][1]
         return [
             f_target_pair[0],
         ], [int(leading_dim), int(leading_dim)]
     if b_target_pair[1]:
-        leading_dim = b_target_pair[1][0] > b_target_pair[1][1]
+        leading_dim = b_target_pair[1][0] < b_target_pair[1][1]
         return [
             b_target_pair[0],
         ], [int(leading_dim), int(leading_dim)]

--- a/colossalai/tensor/utils.py
+++ b/colossalai/tensor/utils.py
@@ -93,10 +93,10 @@ def shard_simulator(target_pair, legal_sharding_dims):
 def mix_gather_simulator(f_target_pair, b_target_pair):
     '''
     Assume index of f and b target pairs are 'f' and 'b'
-    S0S1 => [b, f], (1, 0)
-    S1S0 => [b, f], (0, 1)
-    S01R => [f], (0, 0)
-    RS01 => [b], (0, 0)
+    S0S1 => Input: (f, [0]), (b, [1]) Output: [b, f], (1, 0)
+    S1S0 => Input: (f, [1]), (b, [0]) Output: [b, f], (0, 1)
+    S01R => Input: (f, [0, 1]), (b, []) Output: [f], (0, 0)
+    RS01 => Input: (f, []), (b, [0, 1]) Output: [b], (0, 0)
     '''
     if f_target_pair[1] and b_target_pair[1]:
         leading_dim = b_target_pair[1] > f_target_pair[1]

--- a/colossalai/tensor/utils.py
+++ b/colossalai/tensor/utils.py
@@ -100,13 +100,17 @@ def mix_gather_simulator(f_target_pair, b_target_pair):
     '''
     if f_target_pair[1] and b_target_pair[1]:
         leading_dim = b_target_pair[1] > f_target_pair[1]
-        return (b_target_pair[0], f_target_pair[1]), (leading_dim, leading_dim ^ 1)
+        return [b_target_pair[0], f_target_pair[0]], [int(leading_dim), int(leading_dim ^ 1)]
     if f_target_pair[1]:
         leading_dim = f_target_pair[1][0] > f_target_pair[1][1]
-        return (f_target_pair[0],), (leading_dim, leading_dim)
+        return [
+            f_target_pair[0],
+        ], [int(leading_dim), int(leading_dim)]
     if b_target_pair[1]:
         leading_dim = b_target_pair[1][0] > b_target_pair[1][1]
-        return (b_target_pair[0],), (leading_dim, leading_dim)
+        return [
+            b_target_pair[0],
+        ], [int(leading_dim), int(leading_dim)]
 
 
 # The function is credited to PyTorch Team

--- a/tests/test_tensor/test_mix_gather.py
+++ b/tests/test_tensor/test_mix_gather.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+import pytest
 import torch
 import torch.multiprocessing as mp
 
@@ -304,13 +305,13 @@ def check_comm(rank, world_size, port):
     #  [4, 5, 6, 7]]
     device_mesh = DeviceMesh(physical_mesh_id, mesh_shape, init_process_group=True, need_flatten=True)
 
-    #check_mix_gather_S0S1(device_mesh, rank)
+    check_mix_gather_S0S1(device_mesh, rank)
 
-    #check_two_all_gather_S0S1(device_mesh, rank)
+    check_two_all_gather_S0S1(device_mesh, rank)
 
-    #check_mix_gather_S1S0(device_mesh, rank)
+    check_mix_gather_S1S0(device_mesh, rank)
 
-    #check_two_all_gather_S1S0(device_mesh, rank)
+    check_two_all_gather_S1S0(device_mesh, rank)
 
     check_mix_gather_S01R(device_mesh, rank)
 
@@ -321,6 +322,7 @@ def check_comm(rank, world_size, port):
     check_two_all_gather_RS01(device_mesh, rank)
 
 
+@pytest.mark.skip(reason="Skip because the check functions assume 8 GPUS but CI only have 4 GPUs")
 def test_mix_gather():
     world_size = 8
     run_func = partial(check_comm, world_size=world_size, port=free_port())

--- a/tests/test_tensor/test_mix_gather.py
+++ b/tests/test_tensor/test_mix_gather.py
@@ -1,0 +1,115 @@
+from functools import partial
+
+import torch
+import torch.multiprocessing as mp
+
+from colossalai.core import global_context as gpc
+from colossalai.device.device_mesh import DeviceMesh
+from colossalai.initialize import launch
+from colossalai.logging import disable_existing_loggers
+from colossalai.tensor.shape_consistency import CollectiveCommPattern, CommSpec
+from colossalai.tensor.sharding_spec import ShardingSpec
+from colossalai.tensor.utils import mix_gather_simulator
+from colossalai.utils import free_port
+
+
+def check_mix_gather_S0S1(device_mesh, rank):
+    tensor_to_check = torch.arange(64).reshape((8, 8)).cuda()
+    (f, b) = (0, 1)
+    f_target_pair = (f, [0])
+    b_target_pair = (b, [1])
+    gather_dim, logical_process_axes = mix_gather_simulator(f_target_pair, b_target_pair)
+    tensor_slice = [4, 2]    # (4, 2)
+    rank_slice = 4
+    f_start = (rank // rank_slice) * tensor_slice[0]
+    b_start = (rank % rank_slice) * tensor_slice[1]
+    tensor_to_comm = tensor_to_check[f_start:f_start + tensor_slice[0],
+                                     b_start:b_start + tensor_slice[1]].contiguous().cuda()
+
+    dim_partition_dict = {0: [0], 1: [1]}
+
+    # DistSpec:
+    #     shard_sequence: S0,S1
+    #     device_mesh_shape: (2, 4)
+    source_spec = ShardingSpec(device_mesh, tensor_to_check.shape, dim_partition_dict=dim_partition_dict)
+
+    comm_spec = CommSpec(CollectiveCommPattern.MIXGATHER_FWD_SPLIT_BWD,
+                         sharding_spec=source_spec,
+                         gather_dim=gather_dim,
+                         logical_process_axis=logical_process_axes,
+                         forward_only=True,
+                         mix_gather=True)
+    tensor_to_comm = tensor_to_comm = comm_spec.covert_spec_to_action(tensor_to_comm)
+
+    assert tensor_to_comm.equal(tensor_to_check)
+
+
+def check_mix_gather_S1S0(device_mesh, rank):
+    tensor_to_check = torch.arange(64).reshape((8, 8)).cuda()
+    (f, b) = (0, 1)
+    f_target_pair = (f, [1])
+    b_target_pair = (b, [0])
+    gather_dim, logical_process_axes = mix_gather_simulator(f_target_pair, b_target_pair)
+    tensor_slice = [2, 4]
+    rank_slice = 4
+    f_start = (rank % rank_slice) * tensor_slice[0]
+    b_start = (rank // rank_slice) * tensor_slice[1]
+    tensor_to_comm = tensor_to_check[f_start:f_start + tensor_slice[0],
+                                     b_start:b_start + tensor_slice[1]].contiguous().cuda()
+
+    dim_partition_dict = {0: [1], 1: [0]}
+
+    # DistSpec:
+    #     shard_sequence: S1,S0
+    #     device_mesh_shape: (2, 4)
+    source_spec = ShardingSpec(device_mesh, tensor_to_check.shape, dim_partition_dict=dim_partition_dict)
+
+    comm_spec = CommSpec(CollectiveCommPattern.MIXGATHER_FWD_SPLIT_BWD,
+                         sharding_spec=source_spec,
+                         gather_dim=gather_dim,
+                         logical_process_axis=logical_process_axes,
+                         forward_only=True,
+                         mix_gather=True)
+    tensor_to_comm = tensor_to_comm = comm_spec.covert_spec_to_action(tensor_to_comm)
+
+    if rank == 0:
+        print(tensor_to_comm)
+
+
+def check_mix_gather_S01R(device_mesh, rank):
+    pass
+
+
+def check_mix_gather_RS01(device_mesh, rank):
+    pass
+
+
+def check_comm(rank, world_size, port):
+    disable_existing_loggers()
+    launch(config={}, rank=rank, world_size=world_size, host='localhost', port=port, backend='nccl')
+
+    physical_mesh_id = torch.arange(0, 8)
+    assert rank == gpc.get_global_rank()
+
+    mesh_shape = (2, 4)
+    # [[0, 1, 2, 3],
+    #  [4, 5, 6, 7]]
+    device_mesh = DeviceMesh(physical_mesh_id, mesh_shape, init_process_group=True, need_flatten=True)
+
+    check_mix_gather_S0S1(device_mesh, rank)
+
+    #check_mix_gather_S1S0(device_mesh, rank)
+
+    #check_mix_gather_S01R(device_mesh, rank)
+
+    #check_mix_gather_RS01(device_mesh, rank)
+
+
+def test_comm_spec():
+    world_size = 8
+    run_func = partial(check_comm, world_size=world_size, port=free_port())
+    mp.spawn(run_func, nprocs=world_size)
+
+
+if __name__ == '__main__':
+    test_comm_spec()

--- a/tests/test_tensor/test_mix_gather.py
+++ b/tests/test_tensor/test_mix_gather.py
@@ -163,8 +163,6 @@ def check_two_all_gather_S1S0(device_mesh, rank):
 
 def check_mix_gather_S01R(device_mesh, rank):
     tensor_to_check = torch.arange(64).reshape((8, 8)).cuda()
-    rank_list = [0, 4, 1, 5, 2, 6, 3, 7]
-    rank = rank_list.index(rank)
     (f, b) = (0, 1)
     f_target_pair = (f, [0, 1])
     b_target_pair = (b, [])
@@ -192,8 +190,6 @@ def check_two_all_gather_S01R(device_mesh, rank):
     tensor_width = 8
     tensor_to_check = torch.arange(int(tensor_width * tensor_width)).reshape((tensor_width, tensor_width)).cuda()
 
-    rank_list = [0, 4, 1, 5, 2, 6, 3, 7]
-    rank = rank_list.index(rank)
     rank_stride = tensor_width // 8
     tensor_to_comm = tensor_to_check[rank:rank + rank_stride, :].contiguous().cuda()
 
@@ -208,11 +204,11 @@ def check_two_all_gather_S01R(device_mesh, rank):
     comm_spec = CommSpec(CollectiveCommPattern.GATHER_FWD_SPLIT_BWD,
                          sharding_spec,
                          gather_dim=0,
-                         logical_process_axis=0)
+                         logical_process_axis=1)
 
     tensor_to_comm = comm_spec.covert_spec_to_action(tensor_to_comm)
 
-    dim_partition_dict = {0: [1]}
+    dim_partition_dict = {0: [0]}
 
     # DistSpec:
     #     shard_sequence: S1, R
@@ -223,7 +219,7 @@ def check_two_all_gather_S01R(device_mesh, rank):
     comm_spec = CommSpec(CollectiveCommPattern.GATHER_FWD_SPLIT_BWD,
                          sharding_spec,
                          gather_dim=0,
-                         logical_process_axis=1)
+                         logical_process_axis=0)
 
     tensor_to_comm = comm_spec.covert_spec_to_action(tensor_to_comm)
 
@@ -232,8 +228,7 @@ def check_two_all_gather_S01R(device_mesh, rank):
 
 def check_mix_gather_RS01(device_mesh, rank):
     tensor_to_check = torch.arange(64).reshape((8, 8)).cuda()
-    rank_list = [0, 4, 1, 5, 2, 6, 3, 7]
-    rank = rank_list.index(rank)
+
     (f, b) = (0, 1)
     f_target_pair = (f, [])
     b_target_pair = (b, [0, 1])
@@ -261,8 +256,6 @@ def check_two_all_gather_RS01(device_mesh, rank):
     tensor_width = 8
     tensor_to_check = torch.arange(int(tensor_width * tensor_width)).reshape((tensor_width, tensor_width)).cuda()
 
-    rank_list = [0, 4, 1, 5, 2, 6, 3, 7]
-    rank = rank_list.index(rank)
     rank_stride = tensor_width // 8
     tensor_to_comm = tensor_to_check[:, rank:rank + rank_stride].contiguous().cuda()
 
@@ -277,11 +270,11 @@ def check_two_all_gather_RS01(device_mesh, rank):
     comm_spec = CommSpec(CollectiveCommPattern.GATHER_FWD_SPLIT_BWD,
                          sharding_spec,
                          gather_dim=1,
-                         logical_process_axis=0)
+                         logical_process_axis=1)
 
     tensor_to_comm = comm_spec.covert_spec_to_action(tensor_to_comm)
 
-    dim_partition_dict = {1: [1]}
+    dim_partition_dict = {1: [0]}
 
     # DistSpec:
     #     shard_sequence: R, S1
@@ -292,7 +285,7 @@ def check_two_all_gather_RS01(device_mesh, rank):
     comm_spec = CommSpec(CollectiveCommPattern.GATHER_FWD_SPLIT_BWD,
                          sharding_spec,
                          gather_dim=1,
-                         logical_process_axis=1)
+                         logical_process_axis=0)
 
     tensor_to_comm = comm_spec.covert_spec_to_action(tensor_to_comm)
 
@@ -311,13 +304,13 @@ def check_comm(rank, world_size, port):
     #  [4, 5, 6, 7]]
     device_mesh = DeviceMesh(physical_mesh_id, mesh_shape, init_process_group=True, need_flatten=True)
 
-    check_mix_gather_S0S1(device_mesh, rank)
+    #check_mix_gather_S0S1(device_mesh, rank)
 
-    check_two_all_gather_S0S1(device_mesh, rank)
+    #check_two_all_gather_S0S1(device_mesh, rank)
 
-    check_mix_gather_S1S0(device_mesh, rank)
+    #check_mix_gather_S1S0(device_mesh, rank)
 
-    check_two_all_gather_S1S0(device_mesh, rank)
+    #check_two_all_gather_S1S0(device_mesh, rank)
 
     check_mix_gather_S01R(device_mesh, rank)
 


### PR DESCRIPTION
**What's new?**
Add a one-step transformation called ***mix-gather*** for:

|Src|Dst|
|---|---|
|S0S1|RR|
|S1S0|RR|
|S01R|RR|
|RS01|RR|

**Why do we need this?**
Reduce the communication cost.
Assume $\beta_1 \gt \beta_0$, $M$ is the communication size.
Cost for S0S1=>S0R=>RR is $\frac{M}{n_1n_0}\times\frac{n_1-1}{n_1}\times\beta_1 + \frac{M}{n_1}\times\frac{n_0-1}{n_0}\times\beta_0$
Cost for S0S1=>RR is $\frac{M}{n_0n_1}\times\frac{n_0n_1-1}{n_0n_1}\times\beta_1$

**Pitfalls**
Peak memory increases by the size of a tensor for S0S1=>RR and S1S0=>RR