### PR TITLE
[workflow] added conda cache and fixed no-compilation bug in release

### DIFF
--- a/.github/workflows/release_bdist.yml
+++ b/.github/workflows/release_bdist.yml
@@ -64,9 +64,21 @@ jobs:
       - name: Copy scripts and checkout
         run: |
           cp -r ./.github/workflows/scripts/* ./
+
+          # link the cache diretories to current path
+          ln -s /github/home/conda_pkgs ./conda_pkgs
           ln -s /github/home/pip_wheels ./pip_wheels
+
+          # set the conda package path
+          echo pkgs_dirs:\n\t- $PWD/conda_pkgs > ~/.condarc
+
+          # set safe directory
           git config --global --add safe.directory /__w/ColossalAI/ColossalAI
+
+          # check out
           git checkout $git_ref
+
+          # get cub package for cuda 10.2
           wget https://github.com/NVIDIA/cub/archive/refs/tags/1.8.0.zip
           unzip 1.8.0.zip
         env:

--- a/.github/workflows/scripts/build_colossalai_wheel.sh
+++ b/.github/workflows/scripts/build_colossalai_wheel.sh
@@ -18,7 +18,7 @@ if [ $1 == "pip" ]
 then
     wget -nc -q -O ./pip_wheels/$filename $url
     pip install ./pip_wheels/$filename
-    
+
 elif [ $1 == 'conda' ]
 then
     conda install pytorch==$torch_version cudatoolkit=$cuda_version $flags
@@ -34,8 +34,9 @@ fi
 
 python setup.py bdist_wheel
 mv ./dist/* ./all_dist
+# must remove build to enable compilation for
+# cuda extension in the next build
+rm -rf ./build
 python setup.py clean
 conda deactivate
 conda env remove -n $python_version
-
-


### PR DESCRIPTION
# What does this PR do？

In some previous workflow runs, the wheels distributed do not have cuda extension even though the environment is correct as it uses the extension files from the previous build. In this PR, two things are done:
1. remove the build folder after each bdist build to enable compilation for each build run
2. added conda cache directory to save time on downloading the conda files