### PR TITLE
[workflow] fixed the python and cpu arch mismatch

### DIFF
--- a/.github/workflows/draft_github_release_post.yml
+++ b/.github/workflows/draft_github_release_post.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7.12'
+          python-version: '3.8.14'
       - name: generate draft
         id: generate_draft
         run: |


### PR DESCRIPTION
# What is the problem？

There seems to be an update on the python checkout action, which leads to the error below.

<img width="1137" alt="Screenshot 2022-11-23 at 17 21 04" src="https://user-images.githubusercontent.com/31818963/203510610-3afb171a-392e-402e-b14c-d5bee302257d.png">

# What does this PR do？

To resolve this issue, I have updated the python version in the workflow file to 3.8.14. It works fine on a manually triggered test.

<img width="953" alt="Screenshot 2022-11-23 at 17 22 36" src="https://user-images.githubusercontent.com/31818963/203510831-5b5c6013-e331-4d0b-b9a4-330bff742c65.png">

