### PR TITLE
[autoparallel] complete gpt block searching

### DIFF
--- a/colossalai/auto_parallel/tensor_shard/node_handler/strategy/binary_elementwise_generator.py
+++ b/colossalai/auto_parallel/tensor_shard/node_handler/strategy/binary_elementwise_generator.py
@@ -85,7 +85,7 @@ class BinaryElementwiseStrategyGenerator(StrategyGenerator):
         strategy_list = []
 
         # convert these dim partition dict to sharding strategy
-        for dim_partition_dict in dim_partition_list:
+        for index, dim_partition_dict in enumerate(dim_partition_list):
             dim_partition_dict_mapping = dict(input=dim_partition_dict,
                                               other=dim_partition_dict,
                                               output=dim_partition_dict)
@@ -96,7 +96,7 @@ class BinaryElementwiseStrategyGenerator(StrategyGenerator):
 
                 # get name
                 sharding_seq = sharding_spec_mapping['input'].sharding_sequence
-                name = f'{sharding_seq} = {sharding_seq} <binary-elementwise-op> {sharding_seq}'
+                name = f'{sharding_seq} = {sharding_seq} <binary-elementwise-op> {sharding_seq}_{index}'
                 sharding_strategy = self.get_sharding_strategy(
                     name=name,
                     sharding_spec_mapping=sharding_spec_mapping,

--- a/colossalai/auto_parallel/tensor_shard/node_handler/strategy/layer_norm_generator.py
+++ b/colossalai/auto_parallel/tensor_shard/node_handler/strategy/layer_norm_generator.py
@@ -12,6 +12,7 @@ from colossalai.auto_parallel.tensor_shard.sharding_strategy import (
 from colossalai.auto_parallel.tensor_shard.utils import (
     enumerate_all_possible_1d_sharding,
     enumerate_all_possible_2d_sharding,
+    ignore_sharding_exception,
 )
 from colossalai.tensor.shape_consistency import CollectiveCommPattern
 
@@ -94,6 +95,7 @@ class LayerNormGenerator(StrategyGenerator):
         memory_cost = TrainCycleItem(fwd=fwd_mem_cost, bwd=bwd_mem_cost, total=total_mem_cost)
         strategy.memory_cost = memory_cost
 
+    @ignore_sharding_exception
     def _generate_strategy_with_dim_partition(self, dim_partition):
         dim_partition_dict_mapping = {
             "input": dim_partition,
@@ -151,6 +153,7 @@ class LayerNormGenerator(StrategyGenerator):
             strategy_list.append(strategy)
         return strategy_list
 
+    @ignore_sharding_exception
     def non_split(self):
         name = f'RR = RR x R'
         dim_partition_dict_mapping = {

--- a/colossalai/auto_parallel/tensor_shard/node_handler/unary_elementwise_handler.py
+++ b/colossalai/auto_parallel/tensor_shard/node_handler/unary_elementwise_handler.py
@@ -14,6 +14,8 @@ __all__ = ['UnaryElementwiseHandler']
 @operator_registry.register(torch.Tensor.type)
 @operator_registry.register(torch.abs)
 @operator_registry.register(torch.nn.ReLU)
+@operator_registry.register(torch.nn.Tanh)
+@operator_registry.register(torch.tanh)
 # TODO: softmax need to be relocated
 @operator_registry.register(torch.nn.functional.softmax)
 @operator_registry.register(torch.nn.modules.dropout.Dropout)

--- a/colossalai/auto_parallel/tensor_shard/sharding_strategy.py
+++ b/colossalai/auto_parallel/tensor_shard/sharding_strategy.py
@@ -254,8 +254,9 @@ class StrategiesVector(list):
             if self.node.target in ELEMENTWISE_FUNC_OP:
                 merge_label = True
             # we could merge bcast op if the rhs is a scalar, because it will fall back to the element-wise case.
-            if self.node.target in BCAST_FUNC_OP and len(self.predecessor_nodes) == 1:
-                merge_label = True
+            # TODO: remove this after we support the fall back logic.
+            # if self.node.target in BCAST_FUNC_OP and len(self.predecessor_nodes) == 1:
+            #     merge_label = True
             # we could merge reshape op, because their computation costs are negligible.
             if self.node.target in RESHAPE_FUNC_OP:
                 merge_label = True


### PR DESCRIPTION
### What does this PR do

1. Integrate GPT2Block, GPT2MLP, and GPT2Attention in one unit test file.
2. Temporarily，disable the node merging for a special case of binary element-wise kernel, in that case, one of the two inputs should be a scalar, then the handler will fall back to use the unary element-wise kernel logic to do the strategy registration.