### PR TITLE
[autoparallel] support addbmm computation

### DIFF
--- a/colossalai/fx/tracer/bias_addition_patch/patched_bias_addition_function/__init__.py
+++ b/colossalai/fx/tracer/bias_addition_patch/patched_bias_addition_function/__init__.py
@@ -1,2 +1,3 @@
+from .addbmm import Addbmm
 from .addmm import Addmm
-from .bias_addition_function import BiasAdditionFunc, LinearBasedBiasFunc, func_to_func_dict
+from .bias_addition_function import BiasAdditionFunc, LinearBasedBiasFunc, func_to_func_dict, method_to_func_dict

--- a/colossalai/fx/tracer/bias_addition_patch/patched_bias_addition_function/addbmm.py
+++ b/colossalai/fx/tracer/bias_addition_patch/patched_bias_addition_function/addbmm.py
@@ -1,0 +1,75 @@
+import operator
+
+import torch
+import torch.nn.functional as F
+
+from ...registry import bias_addition_function, bias_addition_method
+from .bias_addition_function import LinearBasedBiasFunc
+
+
+@bias_addition_method.register(torch.Tensor.addbmm)
+@bias_addition_function.register(torch.addbmm)
+class Addbmm(LinearBasedBiasFunc):
+
+    def extract_kwargs_from_origin_func(self):
+        kwargs = {}
+        if 'beta' in self.kwargs:
+            kwargs['beta'] = self.kwargs['beta']
+        if 'alpha' in self.kwargs:
+            kwargs['alpha'] = self.kwargs['alpha']
+        return kwargs
+
+    def create_non_bias_func_proxy(self, input_proxy, other_proxy):
+        """
+        This method is used to create the non_bias_func proxy, the node created by this proxy will
+        compute the main computation, such as convolution, with bias option banned.
+        """
+        assert self.substitute_func == torch.bmm
+        node_kind = 'call_function'
+        node_target = self.substitute_func
+
+        node_args = (input_proxy, other_proxy)
+        # torch.bmm does not have any kwargs
+        node_kwargs = {}
+        non_bias_func_proxy = self.tracer.create_proxy(node_kind, node_target, node_args, node_kwargs)
+        return non_bias_func_proxy
+
+    def insert_sum_node(self, input_proxy, sum_dims=0):
+        '''
+        This method is used to sum the input_proxy through the sum_dims.
+        '''
+        node_kind = 'call_function'
+        node_target = torch.sum
+        node_args = (input_proxy, sum_dims)
+        node_kwargs = {}
+        sum_proxy = self.tracer.create_proxy(node_kind, node_target, node_args, node_kwargs)
+        return sum_proxy
+
+    def generate(self):
+        # The formula for addbmm is output = beta * input + alpha * (torch.bmm(b1, b2))
+
+        # doing the non-bias computation(temp_0 = torch.bmm(b1, b2))
+        non_bias_linear_func_proxy = self.create_non_bias_func_proxy(self.args[1], self.args[2])
+
+        # doing sum on the batch dimension(temp_1 = torch.sum(temp_0, 0))
+        sum_proxy = self.insert_sum_node(non_bias_linear_func_proxy)
+        kwargs = self.extract_kwargs_from_origin_func()
+
+        if 'beta' in kwargs:
+            beta = kwargs['beta']
+            # doing the multiplication with beta if it exists(temp_2 = beta * input)
+            beta_proxy = self.coefficent_for_addmm(self.args[0], beta)
+        else:
+            beta_proxy = self.args[0]
+
+        if 'alpha' in kwargs:
+            alpha = kwargs['alpha']
+            # doing the multiplication with alpha if it exists(temp_3 = alpha * temp_1)
+            alpha_proxy = self.coefficent_for_addmm(alpha, sum_proxy)
+        else:
+            alpha_proxy = sum_proxy
+
+        # doing the addition(temp_4 = temp_2 + temp_3)
+        bias_addition_proxy = self.create_bias_addition_proxy(alpha_proxy, beta_proxy)
+
+        return bias_addition_proxy

--- a/colossalai/fx/tracer/bias_addition_patch/patched_bias_addition_function/addbmm.py
+++ b/colossalai/fx/tracer/bias_addition_patch/patched_bias_addition_function/addbmm.py
@@ -58,14 +58,14 @@ class Addbmm(LinearBasedBiasFunc):
         if 'beta' in kwargs:
             beta = kwargs['beta']
             # doing the multiplication with beta if it exists(temp_2 = beta * input)
-            beta_proxy = self.coefficent_for_addmm(self.args[0], beta)
+            beta_proxy = self.create_mul_node(self.args[0], beta)
         else:
             beta_proxy = self.args[0]
 
         if 'alpha' in kwargs:
             alpha = kwargs['alpha']
             # doing the multiplication with alpha if it exists(temp_3 = alpha * temp_1)
-            alpha_proxy = self.coefficent_for_addmm(alpha, sum_proxy)
+            alpha_proxy = self.create_mul_node(alpha, sum_proxy)
         else:
             alpha_proxy = sum_proxy
 

--- a/colossalai/fx/tracer/registry.py
+++ b/colossalai/fx/tracer/registry.py
@@ -25,3 +25,4 @@ meta_patched_function = PatchRegistry(name='patched_functions_for_meta_execution
 meta_patched_module = PatchRegistry(name='patched_modules_for_meta_execution')
 bias_addition_function = PatchRegistry(name='patched_function_for_bias_addition')
 bias_addition_module = PatchRegistry(name='patched_module_for_bias_addition')
+bias_addition_method = PatchRegistry(name='patched_method_for_bias_addition')


### PR DESCRIPTION
### What does this PR do

1. This PR patches the addbmm node to solve the compatibility issue with bias addition and all reduce. The restructured node looks like:
    original one is:
        %addbmm : [#users=1] = call_function[target=torch.addbmm](args = (%bias, %x1, %x2), kwargs = {})
    Restructured graph is:
        %bmm : [#users=1] = call_function[target=torch.bmm](args = (%x1, %x2), kwargs = {})
        %sum_1 : [#users=1] = call_function[target=torch.sum](args = (%bmm, 0), kwargs = {})
        %add : [#users=1] = call_function[target=operator.add](args = (%sum_1, %bias), kwargs = {})
2. Construct unit tests for it to cover most of the cases, such as different input dims, different function type(torch.addbmm or torch.Tensor.addbmm)