### PR TITLE
[testing] add beit model for unit testings

### DIFF
--- a/tests/components_to_test/__init__.py
+++ b/tests/components_to_test/__init__.py
@@ -1,4 +1,5 @@
 from . import (
+    beit,
     bert,
     gpt2,
     hanging_param_model,
@@ -14,5 +15,5 @@ from . import albert    # isort:skip
 
 __all__ = [
     'bert', 'gpt2', 'hanging_param_model', 'inline_op_model', 'nested_model', 'repeated_computed_layers', 'resnet',
-    'simple_net', 'run_fwd_bwd', 'albert'
+    'simple_net', 'run_fwd_bwd', 'albert', 'beit'
 ]

--- a/tests/components_to_test/beit.py
+++ b/tests/components_to_test/beit.py
@@ -1,5 +1,5 @@
 import torch
-from timm.models import Beit
+from timm.models.beit import Beit
 
 from colossalai.utils.cuda import get_current_device
 
@@ -28,11 +28,12 @@ class DummyDataLoader(DummyDataGenerator):
 def get_training_components():
 
     def model_buider(checkpoint=False):
-        return Beit(img_size=DummyDataLoader.img_size,
-                    num_classes=DummyDataLoader.num_class,
-                    embed_dim=32,
-                    depth=2,
-                    num_heads=4)
+        model = Beit(img_size=DummyDataLoader.img_size,
+                     num_classes=DummyDataLoader.num_class,
+                     embed_dim=32,
+                     depth=2,
+                     num_heads=4)
+        return model
 
     trainloader = DummyDataLoader()
     testloader = DummyDataLoader()

--- a/tests/components_to_test/beit.py
+++ b/tests/components_to_test/beit.py
@@ -1,0 +1,41 @@
+import torch
+from timm.models import Beit
+
+from colossalai.utils.cuda import get_current_device
+
+from .registry import non_distributed_component_funcs
+from .utils.dummy_data_generator import DummyDataGenerator
+
+
+class DummyDataLoader(DummyDataGenerator):
+    img_size = 64
+    num_channel = 3
+    num_class = 10
+    batch_size = 4
+
+    def generate(self):
+        data = torch.randn((DummyDataLoader.batch_size, DummyDataLoader.num_channel, DummyDataLoader.img_size,
+                            DummyDataLoader.img_size),
+                           device=get_current_device())
+        label = torch.randint(low=0,
+                              high=DummyDataLoader.num_class,
+                              size=(DummyDataLoader.batch_size,),
+                              device=get_current_device())
+        return data, label
+
+
+@non_distributed_component_funcs.register(name='beit')
+def get_training_components():
+
+    def model_buider(checkpoint=False):
+        return Beit(img_size=DummyDataLoader.img_size,
+                    num_classes=DummyDataLoader.num_class,
+                    embed_dim=32,
+                    depth=2,
+                    num_heads=4)
+
+    trainloader = DummyDataLoader()
+    testloader = DummyDataLoader()
+
+    criterion = torch.nn.CrossEntropyLoss
+    return model_buider, trainloader, testloader, torch.optim.Adam, criterion

--- a/tests/components_to_test/beit.py
+++ b/tests/components_to_test/beit.py
@@ -38,5 +38,5 @@ def get_training_components():
     trainloader = DummyDataLoader()
     testloader = DummyDataLoader()
 
-    criterion = torch.nn.CrossEntropyLoss
+    criterion = torch.nn.CrossEntropyLoss()
     return model_buider, trainloader, testloader, torch.optim.Adam, criterion

--- a/tests/test_gemini/update/test_optim.py
+++ b/tests/test_gemini/update/test_optim.py
@@ -26,7 +26,7 @@ from tests.test_tensor.common_utils import debug_print, set_seed
 # this model is large enough to slice to chunks
 TEST_MODELS = ['gpt2']
 # these models are too small, all parameters in these models are compacted into one chunk
-EXAMPLE_MODELS = ['albert', 'hanging_param_model', 'bert', 'simple_net', 'nested_model', 'repeated_computed_layers']
+EXAMPLE_MODELS = ['albert', 'beit', 'bert', 'hanging_param_model', 'nested_model', 'repeated_computed_layers']
 
 
 def check_param(model: ZeroDDP, torch_model: torch.nn.Module):

--- a/tests/test_gemini/update/test_optim.py
+++ b/tests/test_gemini/update/test_optim.py
@@ -142,7 +142,7 @@ def exam_tiny_example(placement_policy, model_name: str):
 
         torch_loss = run_fwd_bwd(torch_model, input_ids, label, criterion, torch_optim)
         loss = run_fwd_bwd(model, input_ids, label, criterion, zero_optim)
-        assert_close(torch_loss, loss)
+        assert_close(torch_loss, loss, rtol=1.5e-6, atol=2e-5)    # atol should be 2e-5 for torch lower than 1.12
 
         zero_optim.step()
         torch_optim.step()

--- a/tests/test_tensor/common_utils/_utils.py
+++ b/tests/test_tensor/common_utils/_utils.py
@@ -1,11 +1,13 @@
 import os
 import random
+
 import numpy as np
 import torch
 import torch.distributed as dist
-from colossalai.core import global_context as gpc
+
 from colossalai.context import ParallelMode
-from colossalai.tensor import ShardSpec, ComputeSpec, ComputePattern
+from colossalai.core import global_context as gpc
+from colossalai.tensor import ComputePattern, ComputeSpec, ShardSpec
 
 
 def set_seed(seed):
@@ -15,6 +17,7 @@ def set_seed(seed):
     torch.manual_seed(seed)
     torch.cuda.manual_seed(seed)
     torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
 
 
 def check_equal(A, B):


### PR DESCRIPTION
* added beit model for unit testings
* I didn't enable the checkpoint of the beit model, since it is incompatible with torch 0.1.12. It is a problem that should be blamed on timm liberary.