### PR TITLE
[Gemini] fix the convert_to_torch_module bug

### DIFF
--- a/colossalai/gemini/gemini_mgr.py
+++ b/colossalai/gemini/gemini_mgr.py
@@ -30,7 +30,7 @@ class GeminiManager:
 
     def __init__(self, placement_policy: str, chunk_manager: ChunkManager, memstats: Optional[MemStats] = None) -> None:
 
-        assert placement_policy in PlacementPolicyFactory.get_polocy_names()
+        assert placement_policy in PlacementPolicyFactory.get_policy_names()
         self.policy_name = placement_policy
         policy_cls = PlacementPolicyFactory.create(placement_policy)
         self._chunk_manager = chunk_manager

--- a/colossalai/gemini/placement_policy.py
+++ b/colossalai/gemini/placement_policy.py
@@ -236,7 +236,7 @@ class PlacementPolicyFactory:
         return PlacementPolicyFactory.policies[policy_name]
 
     @staticmethod
-    def get_polocy_names():
+    def get_policy_names():
         return tuple(PlacementPolicyFactory.policies.keys())
 
     @staticmethod

--- a/colossalai/nn/parallel/utils.py
+++ b/colossalai/nn/parallel/utils.py
@@ -2,7 +2,6 @@ import torch
 import torch.distributed as dist
 
 from colossalai.gemini.chunk import Chunk
-from colossalai.tensor import ColoTensor
 from colossalai.utils import get_current_device
 
 
@@ -45,9 +44,7 @@ def convert_to_torch_module(gemini_ddp_model: 'GeminiDDP') -> torch.nn.Module:
     module = gemini_ddp_model.module
 
     # replace ColoTensor to torch.nn.Tensor in module
-    cnt = 0
     for n, p in gemini_ddp_model.torch_named_parameters():
         _add_param(module, n, p)
-        cnt += 1
 
     return module


### PR DESCRIPTION
### What's new

Previously, convert_to_torch_module dose not work. Because it can not find the correct place to store param.data. Now, I fix this bug.

You can test the feature with the following code.

torchrun --standalone --nproc_per_node=1 XXX.py

```
import colossalai
from colossalai.utils import get_current_device
from colossalai.nn.parallel import GeminiDDP
from transformers import BloomForCausalLM, AutoTokenizer
from colossalai.utils.model.colo_init_context import ColoInitContext, post_process_colo_init_ctx
from colossalai.tensor import ColoTensor, ProcessGroup
from colossalai.nn.parallel.utils import convert_to_torch_module


config = {
        "BATCH": 4,
        "gradient_accumulation_steps": 1,
        "clip_grad_norm": 1,
    }

colossalai.launch_from_torch(config=config)

pg = ProcessGroup()

with ColoInitContext():
    model = BloomForCausalLM.from_pretrained("/data2/users/lczht/bloom-560m")

param_num = len([p for n, p in model.named_parameters()])
print(f'param num {param_num}')
# for p in model.parameters():
#    print(p)

# after wrap with GeminiDDP model parameter is broken.
model = GeminiDDP(model,
                device=get_current_device(),
                placement_policy="cuda",
                pin_memory=True,
                search_range_mb=32)

# for n, p in model.torch_named_parameters():
#     print(n, p)

# for k, v in modelv2.state_dict().items():
#     print(k, v)

model = convert_to_torch_module(model)

cnt = 0
for name, param in model.named_parameters(recurse = True):
    if isinstance(param, ColoTensor):
        print('meet ColoTensor', name)
    cnt += 1
print(f'{cnt} params found')
```