### PR TITLE
[workflow] added workflow to release to pypi upon version change

### DIFF
--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -1,0 +1,30 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'version.txt'
+    types:
+      - closed
+
+jobs:
+  build-n-publish:
+    if: github.event_name == "workflow_dispatch" || github.repository == 'hpcaitech/ColossalAI' && github.event.pull_request.merged == true && github.base_ref == 'main' 
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.7.12'
+    - run: python setup.py sdist build
+    # publish to PyPI if executed on the main branch
+    # publish to Test PyPI if executed on the develop branch
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        verbose: true


### PR DESCRIPTION
# What is the problem?

As runtime builder is enabled, we can publish ColossalAI to PYPI so that the users can just install via `pip install colossalai`.

# What does this PR do?

This workflow publish ColossalAI to PYPI automatically whenever `version.txt` is updated.