### PR TITLE
[setup] remove torch dependency

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -3,14 +3,18 @@ import re
 from pathlib import Path
 from typing import List
 
-import torch
-
 
 def get_cuda_cc_flag() -> List:
     """get_cuda_cc_flag
 
     cc flag for your GPU arch
     """
+
+    # only import torch when needed
+    # this is to avoid importing torch when building on a machine without torch pre-installed
+    # one case is to build wheel for pypi release
+    import torch
+    
     cc_flag = []
     for arch in torch.cuda.get_arch_list():
         res = re.search(r'sm_(\d+)', arch)

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,9 @@ try:
     if TORCH_MAJOR < 1 or (TORCH_MAJOR == 1 and TORCH_MINOR < 10):
         raise RuntimeError("Colossal-AI requires Pytorch 1.10 or newer.\n"
                            "The latest stable release can be obtained from https://pytorch.org/")
+    TORCH_AVAILABLE = True
 except ImportError:
-    raise ModuleNotFoundError('torch is not found. You need to install PyTorch before installing Colossal-AI.')
+    TORCH_AVAILABLE = False
 
 
 # ninja build does not work unless include_dirs are abs path
@@ -24,7 +25,7 @@ this_dir = os.path.dirname(os.path.abspath(__file__))
 build_cuda_ext = True
 ext_modules = []
 
-if int(os.environ.get('NO_CUDA_EXT', '0')) == 1:
+if int(os.environ.get('NO_CUDA_EXT', '0')) == 1 or not TORCH_AVAILABLE:
     build_cuda_ext = False
 
 


### PR DESCRIPTION
# Overview

The `setup.py` and `op_builder` both have dependencies on torch, however, during pypi wheel build, the environment is plain Python without torch, leading to build error.

Command to build pypi release: `python setup.py sdist build`

# Issue Number

Fixed #2332 

# What does this PR do?

This PR make the torch dependency optional in both `setup.py` and `op_builder`. With this PR, the command can run without failure.

<img width="766" alt="Screenshot 2023-01-05 at 13 49 10" src="https://user-images.githubusercontent.com/31818963/210710721-95a28f06-de32-4e9f-8485-d6bcb257c946.png">
