### PR TITLE
Update requirement_colossalai.txt

### DIFF
--- a/examples/images/dreambooth/requirement_colossalai.txt
+++ b/examples/images/dreambooth/requirement_colossalai.txt
@@ -5,4 +5,4 @@ ftfy
 tensorboard
 modelcards
 transformers
-colossalai==0.1.11rc5+torch1.12cu11.3 -f https://release.colossalai.org
+colossalai==0.2.0+torch1.12cu11.3 -f https://release.colossalai.org


### PR DESCRIPTION
It is required to install 0.2.0 or install from the source. 

`from colossalai.nn.parallel.utils import convert_to_torch_module` do not work in _0.1.11rc5+torch1.12cu11.3_.