### PR TITLE
[setup] refactored setup.py for dependency graph

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,13 +144,16 @@ if build_cuda_ext:
         print(f'===== Building Extension {name} =====')
         ext_modules.append(builder_cls().builder())
 
-if is_nightly:
+# always put not nightly branch as the if branch
+# otherwise github will treat colossalai-nightly as the project name
+# and it will mess up with the dependency graph insights
+if not is_nightly:
+    version = get_version()
+    package_name = 'colossalai'
+else:
     # use date as the nightly version
     version = datetime.today().strftime('%Y.%m.%d')
     package_name = 'colossalai-nightly'
-else:
-    version = get_version()
-    package_name = 'colossalai'
 
 setup(name=package_name,
       version=version,


### PR DESCRIPTION
# What does this PR do?

This PR updated the `setup.py` to put nightly version after the official release version, such that github will not treat `colossalai-nightly` as the package name.

<img width="1526" alt="Screenshot 2023-01-10 at 11 42 38" src="https://user-images.githubusercontent.com/31818963/211457064-4e2af2bb-c491-46e3-a7c7-084fa7d94684.png">
