### PR TITLE
[workflow] added translation for non-english comments

### DIFF
--- a/.github/workflows/translate_comment.yml
+++ b/.github/workflows/translate_comment.yml
@@ -1,0 +1,18 @@
+name: 'issue-translator'
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: usthe/issues-translate-action@v2.7
+        with:
+          IS_MODIFY_TITLE: false
+          # not require, default false, . Decide whether to modify the issue title
+          # if true, the robot account @Issues-translate-bot must have modification permissions, invite @Issues-translate-bot to your project or use your custom bot.
+          CUSTOM_BOT_NOTE: Bot detected the issue body's language is not English, translate it automatically. 👯👭🏻🧑‍🤝‍🧑👫🧑🏿‍🤝‍🧑🏻👩🏾‍🤝‍👨🏿👬🏿
+          # not require. Customize the translation robot prefix message.


### PR DESCRIPTION
# What does this PR do?

As we have more users, somer users prefer to post their issues/comments in their native languages. However, this can be difficult to understand for other users/developers. Thus, a workflow is added to translate non-English comments to English automatically for internationalization.