### PR TITLE
[workflow] auto comment if precommit check fails

### DIFF
--- a/.github/workflows/auto_example_check.yml
+++ b/.github/workflows/auto_example_check.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Get all changed example files
         id: changed-files
         uses: tj-actions/changed-files@v35
-        # Using this can trigger action each time a PR is submitted.
-        with:
-          since_last_remote_commit: true
       - name: setup matrix
         id: setup-matrix
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
         id: find-changed-files
         uses: tj-actions/changed-files@v35
         with:
-          since_last_remote_commit: true
           files: |
             op_builder/**
             colossalai/kernel/**

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,0 +1,67 @@
+name: Auto Workflow Comment
+
+on:
+  workflow_run:
+    workflows: [pre-commit]
+    types:
+      - completed
+
+jobs:
+  # comment with a message on how to do pre-commit
+  # if the pre-commit check was not passed
+  report-precommit-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.name }} == "pre-commit" && ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr_number"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip pr_number.zip
+
+      - name: 'Comment on PR'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let fs = require('fs');
+            let issue_number = Number(fs.readFileSync('./pr_number'));
+            let owner = context.repo.owner;
+            let repo = context.repo.repo;
+            let run_id = context.payload.workflow_run.id;
+            let run_url = `https://github.com/${owner}/${repo}/actions/runs/${run_id}`
+            let body = `
+            Your pre-commit check failed, follow the steps to run pre-commit on your file for code style consistency.
+
+            1. install pre-commit via "pip install pre-commit"
+            2. install pre-commit hooks via "pre-commit install"
+            3. run pre-commit on file with format error via "pre-commit run --files path" by replacing "path" with the actual file path
+            4. commit and push to your branch
+
+            View your job at ${run_url}.
+            Read our "CONTRIBUTING.md" for more reference to the code style.
+            `;
+            await github.rest.issues.createComment({
+              owner: owner,
+              repo: repo,
+              issue_number: issue_number,
+              body: body
+            });

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -15,8 +15,6 @@ jobs:
     - name: Find the changed files
       id: find-changed-files
       uses: tj-actions/changed-files@v35
-      with:
-        since_last_remote_commit: true
 
     - name: List all changed files
       run: |
@@ -44,3 +42,16 @@ jobs:
           echo "======= running pre-commit on ${file} ======="
           pre-commit run --files $file
         done
+
+    - name: Save PR number
+      if: always()
+      env:
+        PR_NUMBER: ${{ github.event.number }}
+      run: |
+        mkdir -p ./pr
+        echo $PR_NUMBER > ./pr/pr_number
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: pr_number
+        path: pr/


### PR DESCRIPTION
# What does this PR do?

As we have added pre-commit checks on the changed files, we should tell the contributor how to fix the format if the pre-commit check is not passed. This PR added a workflow file which will be triggered if the pre-commit workflow fails and post a comment to the PR automatically.

<img width="924" alt="Screenshot 2023-01-10 at 15 02 30" src="https://user-images.githubusercontent.com/31818963/211483421-6bfcdcd2-59fb-4fd1-84a9-9dd97ff02287.png">


Meanwhile, I have updated the logic of changed file detection to ensure it detects all the changed files.