### PR TITLE
[workflow] report test coverage even if below threshold

### DIFF
--- a/.github/workflows/report_test_coverage.yml
+++ b/.github/workflows/report_test_coverage.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           filename: coverage.xml
           badge: true
-          fail_below_min: true
           format: markdown
           hide_branch_rate: false
           hide_complexity: false


### PR DESCRIPTION
# Issue Number

Fixed #2429 

# What does this PR do?

This PR fixed the workflow parameters such that test coverage is still reported even if the coverage rate is below 80%.