### PR TITLE
[workflow] make test coverage report collapsable

### DIFF
--- a/.github/workflows/report_test_coverage.yml
+++ b/.github/workflows/report_test_coverage.yml
@@ -47,6 +47,12 @@ jobs:
           output: both
           thresholds: '80 90'
 
+      - name: Make Coverage Report Collapsable
+        run: |
+          sed -i '2 i <details>' code-coverage-results.md
+          sed -i '3 i <summary>Click me to view the complete report</summary>' code-coverage-results.md
+          echo "</details>" >> code-coverage-results.md
+
       - name: 'Comment on PR'
         uses: actions/github-script@v6
         with:


### PR DESCRIPTION
# Issue Number 

Fixed #2435 

# What does this PR do?

This PR modified the generated test coverage report in markdown and make the table collapsable. The result will look like this.

<img width="941" alt="Screenshot 2023-01-11 at 11 59 08" src="https://user-images.githubusercontent.com/31818963/211714646-cb38539c-055a-4b29-bf7e-0407e5fa1edc.png">
