### PR TITLE
Fix bug in dreambooth example

### DIFF
--- a/examples/images/dreambooth/train_dreambooth_colossalai.py
+++ b/examples/images/dreambooth/train_dreambooth_colossalai.py
@@ -355,10 +355,11 @@ def gemini_zero_dpp(model: torch.nn.Module, placememt_policy: str = "auto"):
 
 
 def main(args):
-    colossalai.launch_from_torch(config={})
 
-    if args.seed is not None:
-        gpc.set_seed(args.seed)
+    if args.seed is None:
+        colossalai.launch_from_torch(config={})
+    else:
+        colossalai.launch_from_torch(config={}, seed=args.seed)
 
     if args.with_prior_preservation:
         class_images_dir = Path(args.class_data_dir)


### PR DESCRIPTION
There exists a conflict between [gpc.set_seed(seed)](https://github.com/hpcaitech/ColossalAI/blob/169954f87e9d79af0990cd286d89a5308cb21532/colossalai/initialize.py#L113) and [gpc.set_seed(args.seed)](https://github.com/hpcaitech/ColossalAI/blob/main/examples/images/dreambooth/train_dreambooth_colossalai.py#L361) that leads to issue https://github.com/hpcaitech/ColossalAI/issues/2380.

This PR solves this problem.