### PR TITLE
[cli] fixed hostname mismatch error

### DIFF
--- a/colossalai/cli/launcher/hostinfo.py
+++ b/colossalai/cli/launcher/hostinfo.py
@@ -1,5 +1,5 @@
-from typing import List
 import socket
+from typing import List
 
 
 class HostInfo:
@@ -35,9 +35,14 @@ class HostInfo:
 
         if port is None:
             port = 22    # no port specified, lets just use the ssh port
-        hostname = socket.getfqdn(hostname)
+
+        # socket.getfqdn("127.0.0.1") does not return localhost
+        # on some users' machines
+        # thus, we directly return True if hostname is locahost, 127.0.0.1 or 0.0.0.0
         if hostname in ("localhost", "127.0.0.1", "0.0.0.0"):
             return True
+
+        hostname = socket.getfqdn(hostname)
         localhost = socket.gethostname()
         localaddrs = socket.getaddrinfo(localhost, port)
         targetaddrs = socket.getaddrinfo(hostname, port)


### PR DESCRIPTION
# What does this PR do?

Some users encountered errors when running `colossalai run` on localhost, such as the one in the [discussion](https://github.com/hpcaitech/ColossalAI/discussions/2160). This is because `socket.getfqdn("127.0.0.1")` does not always return `"localhost"`. As a result, Colossal-AI treats `127.0.0.1` as a remote host instead.

This PR fixed this issue by making sure it is always treated as localhost.