### PR TITLE
[workflow] fixed changed file detection

### DIFF
--- a/.github/workflows/auto_example_check.yml
+++ b/.github/workflows/auto_example_check.yml
@@ -25,9 +25,21 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Locate base commit
+        id: locate-base-sha
+        run: |
+            curBranch=$(git rev-parse --abbrev-ref HEAD)
+            commonCommit=$(git merge-base origin/main $curBranch)
+            echo $commonCommit
+            echo "baseSHA=$commonCommit" >> $GITHUB_OUTPUT
+
       - name: Get all changed example files
         id: changed-files
         uses: tj-actions/changed-files@v35
+        with:
+          base_sha: ${{ steps.locate-base-sha.outputs.baseSHA }}
+
       - name: setup matrix
         id: setup-matrix
         run: |
@@ -67,9 +79,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
+
       - name: Install Colossal-AI
         run: |
           pip install -v .
+
       - name: Test the example
         run: |
           example_dir=${{ matrix.directory }}
@@ -91,6 +105,7 @@ jobs:
     steps:
     - name: 📚 Checkout
       uses: actions/checkout@v3
+
     - name: setup matrix
       id: setup-matrix
       run: |
@@ -115,9 +130,11 @@ jobs:
     steps:
       - name: 📚 Checkout
         uses: actions/checkout@v3
+
       - name: Install Colossal-AI
         run: |
           pip install -v .
+
       - name: Traverse all files
         run: |
           example_dir=${{ matrix.diretory }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,14 +21,25 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Locate base commit
+        id: locate-base-sha
+        run: |
+            curBranch=$(git rev-parse --abbrev-ref HEAD)
+            commonCommit=$(git merge-base origin/main $curBranch)
+            echo $commonCommit
+            echo "baseSHA=$commonCommit" >> $GITHUB_OUTPUT
+
       - name: Find the changed files
         id: find-changed-files
         uses: tj-actions/changed-files@v35
         with:
+          base_sha: ${{ steps.locate-base-sha.outputs.baseSHA }}
           files: |
             op_builder/**
             colossalai/kernel/**
             setup.py
+
       - name: List changed files
         run: |
           for file in ${{ steps.find-changed-files.outputs.all_changed_files }}; do

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -12,9 +12,23 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
+    # the PR branch and the hpcaitech/colossal-ai main branch
+    # must share a common commit, we need to locate that commit,
+    # which is the commit checked-out or forked when the PR branch is created
+    # such that we can look for files changed since that commit
+    - name: Locate base commit
+      id: locate-base-sha
+      run: |
+          curBranch=$(git rev-parse --abbrev-ref HEAD)
+          commonCommit=$(git merge-base origin/main $curBranch)
+          echo $commonCommit
+          echo "baseSHA=$commonCommit" >> $GITHUB_OUTPUT
+
     - name: Find the changed files
       id: find-changed-files
       uses: tj-actions/changed-files@v35
+      with:
+        base_sha: ${{ steps.locate-base-sha.outputs.baseSHA }}
 
     - name: List all changed files
       run: |


### PR DESCRIPTION
# Issue Number

Fixed #2513 .

# What does this PR do?

This PR added one more step to locate the base commit for the `origin/main` and the PR branch. This base commit is used as the `base_sha` for `git diff` such that only the PR branch commits are considered for changed file detection.