### PR TITLE
[workflow] fixed broken release workflows

### DIFF
--- a/.github/workflows/release_docker_after_merge.yml
+++ b/.github/workflows/release_docker_after_merge.yml
@@ -59,8 +59,7 @@ jobs:
         id: message-preparation
         run: |
           url=$SERVER_URL/$REPO/actions/runs/$RUN_ID
-
-          if [ $STATUS == 'success' ]
+          if [ "$STATUS" == 'success' ]
           then
             msg="The Docker image for the latest release has been successfully built and pushed to DockerHub."
           else
@@ -73,4 +72,4 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
           WEBHOOK_URL: ${{ secrets.LARK_NOTIFICATION_WEBHOOK_URL }}
-          STATUS: ${{ steps.docker-push.outcome }}
+          STATUS: ${{ needs.release.result }}

--- a/.github/workflows/release_pypi_after_merge.yml
+++ b/.github/workflows/release_pypi_after_merge.yml
@@ -34,7 +34,7 @@ jobs:
 
   notify:
     name: Notify Lark via webhook
-    needs: release
+    needs: build-n-publish
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:
@@ -52,7 +52,7 @@ jobs:
         run: |
           url=$SERVER_URL/$REPO/actions/runs/$RUN_ID
 
-          if [ $STATUS == 'success' ]
+          if [ "$STATUS" == 'success' ]
           then
             msg="The Colossal-AI latest version has been successfully released to PyPI."
           else
@@ -65,4 +65,4 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
           WEBHOOK_URL: ${{ secrets.LARK_NOTIFICATION_WEBHOOK_URL }}
-          STATUS: ${{ steps.publish.outcome }}
+          STATUS: ${{ needs.build-n-publish.result }}

--- a/.github/workflows/scripts/generate_release_draft.py
+++ b/.github/workflows/scripts/generate_release_draft.py
@@ -57,7 +57,12 @@ def collate_release_info(commit_info_list):
 
     for commit_info in commit_info_list:
         author = commit_info['commit']['author']['name']
-        author_url = commit_info['author']['url']
+
+        try:
+            author_url = commit_info['author']['url']
+        except:
+            # author can be None
+            author_url = None
         msg = commit_info['commit']['message']
         match = re.search(pattern, msg)
 
@@ -86,7 +91,10 @@ def generate_release_post_markdown(current_version, last_version, release_info):
             # only keep the first line
             msg = msg.split('\n')[0]
 
-            item = f'{msg} by [{author}]({author_url})\n'
+            if author_url:
+                item = f'{msg} by [{author}]({author_url})\n'
+            else:
+                item = f'{msg} by {author}\n'
             text.append(f'- {item}')
 
         text.append('\n')


### PR DESCRIPTION
## 📌 Checklist before creating the PR

- [x] I have created an issue for this PR for traceability
- [x] The title follows the standard format: `[doc/gemini/tensor/...]: A concise description`
- [x] I have added relevant tags if possible for us to better distinguish different PRs


## 🚨 Issue number

> Link this PR to your issue with words like fixed to automatically close the linked issue upon merge
>
> e.g. `fixed #1234`, `closed #1234`, `resolved #1234`

Fixed #2603 .


## 📝 What does this PR do?

> Summarize your work here.
> if you have any plots/diagrams/screenshots/tables, please attach them here.

This PR fixed the three release workflows. The root cause for each workflow error is:
1. draft release post: the github api response can have value None for the field author
2. release to pypi: the `needs` field has the wrong job name
3. release to docker: the job status has the wrong github actions context variable

## 💥 Checklist before requesting a review

- [x] I have linked my PR to an issue ([instruction](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
- [x] My issue clearly describes the problem/feature/proposal, with diagrams/charts/table/code if possible
- [x] I have performed a self-review of my code
- [x] I have added thorough tests.
- [x] I have added docstrings for all the functions/methods I implemented

## ⭐️ Do you enjoy contributing to Colossal-AI?

- [x] 🌝 Yes, I do.
- [ ] 🌚 No, I don't.

Tell us more if you don't enjoy contributing to Colossal-AI.
