### PR TITLE
Don't use `torch._six`

### DIFF
--- a/colossalai/utils/common.py
+++ b/colossalai/utils/common.py
@@ -11,7 +11,7 @@ from typing import Callable, Dict, List, Optional, Union
 
 import torch
 import torch.distributed as dist
-from torch._six import inf
+from torch import inf
 from torch.nn.parameter import Parameter
 
 from colossalai.constants import IS_TENSOR_PARALLEL, NUM_PARTITIONS, TENSOR_PARALLEL_ATTRIBUTES

--- a/colossalai/zero/sharded_optim/_utils.py
+++ b/colossalai/zero/sharded_optim/_utils.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import torch
 import torch.distributed as dist
-from torch._six import inf
+from torch.six import inf
 from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 
 from colossalai.tensor import ColoParameter


### PR DESCRIPTION
This is a private API which is gone after https://github.com/pytorch/pytorch/pull/94709


## 🚨 Issue number

Fixed https://github.com/hpcaitech/ColossalAI/issues/2774



## 📝 What does this PR do?
Use `inf` from `torch`, rather than from `torch._six`

`s/from torch._six import inf/from torch import inf/`


## 💥 Checklist before requesting a review

- [x] I have linked my PR to an issue ([instruction](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
- [x] My issue clearly describes the problem/feature/proposal, with diagrams/charts/table/code if possible
- [x] I have performed a self-review of my code
- [x] I have added thorough tests.
- [x] I have added docstrings for all the functions/methods I implemented

## ⭐️ Do you enjoy contributing to Colossal-AI?

- [x] 🌝 Yes, I do.
- [x] 🌚 No, I don't.

Tell us more if you don't enjoy contributing to Colossal-AI.
