### PR TITLE
[hotfix]: Remove math.prod dependency

### DIFF
--- a/colossalai/nn/_ops/view.py
+++ b/colossalai/nn/_ops/view.py
@@ -1,5 +1,8 @@
-import math
+from functools import reduce
+import operator
+
 import torch
+
 from colossalai.tensor.op_wrapper import colo_op_impl
 from colossalai.tensor import ColoTensor, ColoTensorSpec, ReplicaSpec
 from typing import Optional, Union
@@ -37,8 +40,8 @@ def _shape_infer(org_sp, tgt_sp):
     if cnt > 1:
         raise RuntimeError("only one dimension can be inferred")
 
-    org_prod = math.prod(org_sp)
-    tgt_prod = math.prod(tgt_sp)
+    org_prod = reduce(operator.mul, org_sp, 1)
+    tgt_prod = reduce(operator.mul, tgt_sp, 1)
 
     if cnt == 0:
         if org_prod != tgt_prod:

--- a/colossalai/nn/_ops/view.py
+++ b/colossalai/nn/_ops/view.py
@@ -1,11 +1,11 @@
-from functools import reduce
 import operator
+from functools import reduce
+from typing import Optional, Union
 
 import torch
 
-from colossalai.tensor.op_wrapper import colo_op_impl
 from colossalai.tensor import ColoTensor, ColoTensorSpec, ReplicaSpec
-from typing import Optional, Union
+from colossalai.tensor.op_wrapper import colo_op_impl
 
 
 def _all_int(my_iter):
@@ -52,7 +52,7 @@ def _shape_infer(org_sp, tgt_sp):
         raise RuntimeError("shape '{}' is invalid for input of size {}".format(tgt_sp, org_prod))
 
     infer_dim = -(org_prod // tgt_prod)
-    return tgt_sp[: pos] + (infer_dim,) + tgt_sp[pos + 1:]
+    return tgt_sp[:pos] + (infer_dim,) + tgt_sp[pos + 1:]
 
 
 @colo_op_impl(torch.Tensor.view)
@@ -80,15 +80,11 @@ def colo_view(self: ColoTensor, *shape) -> 'ColoTensor':
         res = self.view(*new_shape)
     else:
         replicated_t = self.redistribute(dist_spec=ReplicaSpec())
-        return ColoTensor.from_torch_tensor(
-            tensor=replicated_t.view(*shape),
-            spec=ColoTensorSpec(self.get_process_group()))
+        return ColoTensor.from_torch_tensor(tensor=replicated_t.view(*shape),
+                                            spec=ColoTensorSpec(self.get_process_group()))
 
-    return ColoTensor.from_torch_tensor(
-        tensor=res,
-        spec=ColoTensorSpec(
-            pg=self.get_process_group(),
-            dist_attr=self.dist_spec))
+    return ColoTensor.from_torch_tensor(tensor=res,
+                                        spec=ColoTensorSpec(pg=self.get_process_group(), dist_attr=self.dist_spec))
 
 
 @colo_op_impl(torch.Tensor.size)

--- a/colossalai/tensor/colo_tensor.py
+++ b/colossalai/tensor/colo_tensor.py
@@ -1,6 +1,6 @@
+import operator
 from copy import copy
 from functools import lru_cache, reduce
-import operator
 from typing import Callable, Optional, Set
 
 import torch

--- a/colossalai/tensor/colo_tensor.py
+++ b/colossalai/tensor/colo_tensor.py
@@ -1,6 +1,6 @@
-import math
 from copy import copy
-from functools import lru_cache
+from functools import lru_cache, reduce
+import operator
 from typing import Callable, Optional, Set
 
 import torch
@@ -312,7 +312,7 @@ class ColoTensor(torch.Tensor):
     def numel_global(self):
         """Returns the number of elements in the tensor when it's replicated.
         """
-        return math.prod(self.size_global())
+        return reduce(operator.mul, self.size_global(), 1)
 
     # Some API for dist spec check
 


### PR DESCRIPTION
## 📌 Checklist before creating the PR

- [x] I have created an issue for this PR for traceability
- [x] The title follows the standard format: `[doc/gemini/tensor/...]: A concise description`
- [ ] I have added relevant tags if possible for us to better distinguish different PRs


## 🚨 Issue number

Fixed #2832

## 📝 What does this PR do?

Removes dependency on the `math.prod` functionality and replaces it with `reduce` and `operator.mul` that are backward compatible with Python3.7.

## 💥 Checklist before requesting a review

- [x] I have linked my PR to an issue ([instruction](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
- [x] My issue clearly describes the problem/feature/proposal, with diagrams/charts/table/code if possible
- [x] I have performed a self-review of my code
- [ ] I have added thorough tests.
- [ ] I have added docstrings for all the functions/methods I implemented

## ⭐️ Do you enjoy contributing to Colossal-AI?

- [x] 🌝 Yes, I do.
- [ ] 🌚 No, I don't.

Tell us more if you don't enjoy contributing to Colossal-AI.
