### PR TITLE
[chatgpt] change critic input as state

### DIFF
--- a/applications/ChatGPT/chatgpt/models/base/critic.py
+++ b/applications/ChatGPT/chatgpt/models/base/critic.py
@@ -41,7 +41,7 @@ class Critic(LoRAModule):
         if action_mask is not None:
             num_actions = action_mask.size(1)
             prompt_mask = attention_mask[:, :-num_actions]
-            values = values[:, :num_actions]
+            values = values[:, :-num_actions]
             value = masked_mean(values, prompt_mask, dim=1)
             return value
         values = values[:, :-1]

--- a/applications/ChatGPT/chatgpt/models/base/critic.py
+++ b/applications/ChatGPT/chatgpt/models/base/critic.py
@@ -40,8 +40,8 @@ class Critic(LoRAModule):
 
         if action_mask is not None:
             num_actions = action_mask.size(1)
-            prompt_mask = attention_mask[:, :-(num_actions + 1)]
-            values = values[:, :-(num_actions + 1)]
+            prompt_mask = attention_mask[:, :-num_actions]
+            values = values[:, :num_actions]
             value = masked_mean(values, prompt_mask, dim=1)
             return value
         values = values[:, :-1]

--- a/applications/ChatGPT/chatgpt/models/base/critic.py
+++ b/applications/ChatGPT/chatgpt/models/base/critic.py
@@ -36,13 +36,14 @@ class Critic(LoRAModule):
         outputs = self.model(sequences, attention_mask=attention_mask)
         last_hidden_states = outputs['last_hidden_state']
 
-        values = self.value_head(last_hidden_states).squeeze(-1)[:, :-1]
+        values = self.value_head(last_hidden_states).squeeze(-1)
 
         if action_mask is not None:
-            prompt_mask = torch.ones_like(attention_mask)
+            prompt_mask = torch.ones_like(values)
             num_actions = action_mask.size(1)
-            prompt_mask[:, -num_actions:] = 0
+            prompt_mask[:, -(num_actions+1):] = 0
             value = masked_mean(values, prompt_mask, dim=1)
             return value
+        values = values[:, :-1]
         value = values.mean(dim=1).squeeze(1)
         return value

--- a/applications/ChatGPT/chatgpt/models/base/critic.py
+++ b/applications/ChatGPT/chatgpt/models/base/critic.py
@@ -39,9 +39,10 @@ class Critic(LoRAModule):
         values = self.value_head(last_hidden_states).squeeze(-1)[:, :-1]
 
         if action_mask is not None:
+            prompt_mask = torch.ones_like(attention_mask)
             num_actions = action_mask.size(1)
-            values = values[:, -num_actions:]
-            value = masked_mean(values, action_mask, dim=1)
+            prompt_mask[:, -num_actions:] = 0
+            value = masked_mean(values, prompt_mask, dim=1)
             return value
         value = values.mean(dim=1).squeeze(1)
         return value

--- a/applications/ChatGPT/chatgpt/models/base/critic.py
+++ b/applications/ChatGPT/chatgpt/models/base/critic.py
@@ -39,9 +39,9 @@ class Critic(LoRAModule):
         values = self.value_head(last_hidden_states).squeeze(-1)
 
         if action_mask is not None:
-            prompt_mask = torch.ones_like(values, dtype=torch.bool)
             num_actions = action_mask.size(1)
-            prompt_mask[:, -(num_actions+1):] = False
+            prompt_mask = attention_mask[:, :-(num_actions + 1)]
+            values = values[:, :-(num_actions + 1)]
             value = masked_mean(values, prompt_mask, dim=1)
             return value
         values = values[:, :-1]

--- a/applications/ChatGPT/chatgpt/models/base/critic.py
+++ b/applications/ChatGPT/chatgpt/models/base/critic.py
@@ -44,5 +44,7 @@ class Critic(LoRAModule):
             values = values[:, :-num_actions]
             value = masked_mean(values, prompt_mask, dim=1)
             return value
+
         values = values[:, :-1]
         value = values.mean(dim=1).squeeze(1)
+        return value

--- a/applications/ChatGPT/chatgpt/models/base/critic.py
+++ b/applications/ChatGPT/chatgpt/models/base/critic.py
@@ -39,11 +39,10 @@ class Critic(LoRAModule):
         values = self.value_head(last_hidden_states).squeeze(-1)
 
         if action_mask is not None:
-            prompt_mask = torch.ones_like(values)
+            prompt_mask = torch.ones_like(values, dtype=torch.bool)
             num_actions = action_mask.size(1)
-            prompt_mask[:, -(num_actions+1):] = 0
+            prompt_mask[:, -(num_actions+1):] = False
             value = masked_mean(values, prompt_mask, dim=1)
             return value
         values = values[:, :-1]
         value = values.mean(dim=1).squeeze(1)
-        return value


### PR DESCRIPTION
> ## 📌 Checklist before creating the PR
> * [x]  I have created an issue for this PR for traceability
> * [x]  The title follows the standard format: `[doc/gemini/tensor/...]: A concise description`
> * [ ]  I have added relevant tags if possible for us to better distinguish different PRs
> 
> ## 🚨 Issue number
> > Link this PR to your issue with words like fixed to automatically close the linked issue upon merge
> > e.g. `fixed #1234`, `closed #1234`, `resolved #1234`
> > fixed #3042
> 
> ## 📝 What does this PR do?
> > Summarize your work here.
> > if you have any plots/diagrams/screenshots/tables, please attach them here.
> 
> This commit fix chatgpt critic input as state according to A2C RL algorithm.
> 
> ## 💥 Checklist before requesting a review
> * [x]  I have linked my PR to an issue ([instruction](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
> * [x]  My issue clearly describes the problem/feature/proposal, with diagrams/charts/table/code if possible
> * [x]  I have performed a self-review of my code
> * [ ]  I have added thorough tests.
> * [ ]  I have added docstrings for all the functions/methods I implemented
> 
> ## ⭐️ Do you enjoy contributing to Colossal-AI?
> * [x]  🌝 Yes, I do.
> * [ ]  🌚 No, I don't.
> 
> Tell us more if you don't enjoy contributing to Colossal-AI.

