### PR TITLE
[doc] moved doc test command to bottom

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,7 +72,7 @@ Meanwhile, you need to ensure the `sidebars.json` is updated such that it contai
 
 ### 🧹 Doc Testing
 
-Every documentation is tested to ensure it works well. You need to add the following line to the top of your file and replace `$command` with the actual command. Do note that the markdown will be converted into a Python file. Assuming you have a `demo.md` file, the test file generated will be `demo.py`. Therefore, you should use `demo.py` in your command, e.g. `python demo.py`.
+Every documentation is tested to ensure it works well. You need to add the following line to the **bottom of your file** and replace `$command` with the actual command. Do note that the markdown will be converted into a Python file. Assuming you have a `demo.md` file, the test file generated will be `demo.py`. Therefore, you should use `demo.py` in your command, e.g. `python demo.py`.
 
 ```markdown
 <!-- doc-test-command: $command  -->

--- a/docs/source/en/features/nvme_offload.md
+++ b/docs/source/en/features/nvme_offload.md
@@ -1,4 +1,3 @@
-<!-- doc-test-command: torchrun --standalone --nproc_per_node=1 nvme_offload.py  -->
 # NVMe offload
 
 Author: Hongxin Liu
@@ -259,3 +258,6 @@ NVME offload saves about 294 MB memory. Note that enabling `pin_memory` of Gemin
 {{ autodoc:colossalai.nn.optimizer.HybridAdam }}
 
 {{ autodoc:colossalai.nn.optimizer.CPUAdam }}
+
+
+<!-- doc-test-command: torchrun --standalone --nproc_per_node=1 nvme_offload.py  -->

--- a/docs/source/en/get_started/installation.md
+++ b/docs/source/en/get_started/installation.md
@@ -1,12 +1,10 @@
-<!-- doc-test-command: echo "installation.md does not need test" -->
-
 # Setup
 
 Requirements:
 - PyTorch >= 1.11 (PyTorch 2.x in progress)
 - Python >= 3.7
 - CUDA >= 11.0
-  
+
 If you encounter any problem about installation, you may want to raise an [issue](https://github.com/hpcaitech/ColossalAI/issues/new/choose) in this repository.
 
 
@@ -47,3 +45,6 @@ If you don't want to install and enable CUDA kernel fusion (compulsory installat
 ```shell
 CUDA_EXT=1 pip install .
 ```
+
+
+<!-- doc-test-command: echo "installation.md does not need test" -->

--- a/docs/source/zh-Hans/features/nvme_offload.md
+++ b/docs/source/zh-Hans/features/nvme_offload.md
@@ -1,4 +1,3 @@
-<!-- doc-test-command: torchrun --standalone --nproc_per_node=1 nvme_offload.py  -->
 # NVMe offload
 
 作者: Hongxin Liu
@@ -247,3 +246,6 @@ NVME 卸载节省了大约 294 MB 内存。注意使用 Gemini 的 `pin_memory` 
 {{ autodoc:colossalai.nn.optimizer.HybridAdam }}
 
 {{ autodoc:colossalai.nn.optimizer.CPUAdam }}
+
+
+<!-- doc-test-command: torchrun --standalone --nproc_per_node=1 nvme_offload.py  -->

--- a/docs/source/zh-Hans/get_started/installation.md
+++ b/docs/source/zh-Hans/get_started/installation.md
@@ -5,7 +5,7 @@
 - PyTorch >= 1.11 (PyTorch 2.x 正在适配中)
 - Python >= 3.7
 - CUDA >= 11.0
-  
+
 如果你遇到安装问题，可以向本项目 [反馈](https://github.com/hpcaitech/ColossalAI/issues/new/choose)。
 
 ## 从PyPI上安装
@@ -44,3 +44,5 @@ pip install .
 ```shell
 NO_CUDA_EXT=1 pip install .
 ```
+
+<!-- doc-test-command: echo "installation.md does not need test" -->


### PR DESCRIPTION
## 📌 Checklist before creating the PR

- [x] I have created an issue for this PR for traceability
- [x] The title follows the standard format: `[doc/gemini/tensor/...]: A concise description`
- [x] I have added relevant tags if possible for us to better distinguish different PRs


## 🚨 Issue number

> Link this PR to your issue with words like fixed to automatically close the linked issue upon merge
>
> e.g. `fixed #1234`, `closed #1234`, `resolved #1234`

Fixed #3074 

## 📝 What does this PR do?

> Summarize your work here.
> if you have any plots/diagrams/screenshots/tables, please attach them here.

This PR fixed the documentation sidebar name. The root cause is that `Docusaurus` takes the first line of the markdown file as the sidebar title. Therefore, we need to move `doc-test-command` declaration to the bottom of the file instead.

## 💥 Checklist before requesting a review

- [x] I have linked my PR to an issue ([instruction](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
- [x] My issue clearly describes the problem/feature/proposal, with diagrams/charts/table/code if possible
- [x] I have performed a self-review of my code
- [x] I have added thorough tests.
- [x] I have added docstrings for all the functions/methods I implemented

## ⭐️ Do you enjoy contributing to Colossal-AI?

- [x] 🌝 Yes, I do.
- [ ] 🌚 No, I don't.

Tell us more if you don't enjoy contributing to Colossal-AI.
