### PR TITLE
Fix colossalai training strategies

### DIFF
--- a/applications/ChatGPT/chatgpt/trainer/strategies/colossalai.py
+++ b/applications/ChatGPT/chatgpt/trainer/strategies/colossalai.py
@@ -173,13 +173,13 @@ class ColossalAIStrategy(DDPStrategy):
                 module.eval()
         # get state_dict and save
 
-        if not isinstance(self.model, PreTrainedModel):
+        if not isinstance(model, PreTrainedModel):
             state_dict = unwrapped_model.state_dict()
             if only_rank0 and dist.get_rank() != 0:
                 return
             torch.save(state_dict, path)
         else:
-            self.model.save_pretrained(path)
+            model.save_pretrained(path)
             if tokenizer is not None:
                 tokenizer.save_pretrained(path)
 


### PR DESCRIPTION
Fixes https://github.com/hpcaitech/ColossalAI/issues/3240

Proposed fix for using `colossalai` training strategies, e.g. fix for the following error:

```
Traceback (most recent call last):
  File "train_prompts.py", line 132, in <module>
    main(args)
  File "train_prompts.py", line 106, in main
    strategy.save_model(actor, args.save_path, only_rank0=True)
  File "/home/agruzdev/.virtualenvs/colossalai/lib/python3.8/site-packages/chatgpt-1.0.0-py3.8.egg/chatgpt/trainer/strategies/colossalai.py", line 176, in save_model
AttributeError: 'ColossalAIStrategy' object has no attribute 'model'
```

## 📌 Checklist before creating the PR

- [x] I have created an issue for this PR for traceability
- [ ] The title follows the standard format: `[doc/gemini/tensor/...]: A concise description`
- [ ] I have added relevant tags if possible for us to better distinguish different PRs


## 🚨 Issue number

> Link this PR to your issue with words like fixed to automatically close the linked issue upon merge
>
> e.g. `fixed #1234`, `closed #1234`, `resolved #1234`



## 📝 What does this PR do?

> Summarize your work here.
> if you have any plots/diagrams/screenshots/tables, please attach them here.



## 💥 Checklist before requesting a review

- [x] I have linked my PR to an issue ([instruction](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
- [x] My issue clearly describes the problem/feature/proposal, with diagrams/charts/table/code if possible
- [x] I have performed a self-review of my code
- [ ] I have added thorough tests.
- [ ] I have added docstrings for all the functions/methods I implemented

## ⭐️ Do you enjoy contributing to Colossal-AI?

- [x] 🌝 Yes, I do.
- [ ] 🌚 No, I don't.

Tell us more if you don't enjoy contributing to Colossal-AI.
