### PR TITLE
[gemini] state dict supports fp16

### DIFF
--- a/colossalai/zero/gemini/gemini_ddp.py
+++ b/colossalai/zero/gemini/gemini_ddp.py
@@ -247,7 +247,9 @@ class ZeroDDP(ColoDDP):
         """
         # save parameters
         chunk_to_save_data = dict()
-        temp_chunk = get_temp_total_chunk_on_cuda(chunk).to(dtype)
+        temp_chunk = get_temp_total_chunk_on_cuda(chunk)
+        if torch.is_floating_point(temp_chunk):
+            temp_chunk = temp_chunk.to(dtype)
         for tensor, tensor_info in chunk.tensors_info.items():
             record_tensor = torch.empty([0])
             record_flag = (not only_rank_0) | (dist.get_rank(chunk.torch_pg) == 0)

--- a/tests/test_zero/test_gemini/test_zeroddp_state_dict.py
+++ b/tests/test_zero/test_gemini/test_zeroddp_state_dict.py
@@ -81,7 +81,7 @@ def exam_load_state_dict(placement_policy, keep_gathered, model_name: str):
 
     torch_dict = torch_model.state_dict()
     model.load_state_dict(torch_dict, strict=False)
-    zero_dict = model.state_dict(only_rank_0=False)
+    zero_dict = model.state_dict(only_rank_0=False, dtype=torch.float32)
 
     for key, value in torch_dict.items():
         assert key in zero_dict, "{} not in ZeRO dictionary.".format(key)

--- a/tests/test_zero/test_gemini/test_zeroddp_state_dict.py
+++ b/tests/test_zero/test_gemini/test_zeroddp_state_dict.py
@@ -81,7 +81,7 @@ def exam_load_state_dict(placement_policy, keep_gathered, model_name: str):
 
     torch_dict = torch_model.state_dict()
     model.load_state_dict(torch_dict, strict=False)
-    zero_dict = model.state_dict(only_rank_0=False, dtype=torch.float32)
+    zero_dict = model.state_dict(only_rank_0=False)
 
     for key, value in torch_dict.items():
         assert key in zero_dict, "{} not in ZeRO dictionary.".format(key)


### PR DESCRIPTION
## 📌 Checklist before creating the PR

- [ ] I have created an issue for this PR for traceability
- [x] The title follows the standard format: `[doc/gemini/tensor/...]: A concise description`
- [x] I have added relevant tags if possible for us to better distinguish different PRs


## 🚨 Issue number

> Link this PR to your issue with words like fixed to automatically close the linked issue upon merge
>
> e.g. `fixed #1234`, `closed #1234`, `resolved #1234`



## 📝 What does this PR do?

> Summarize your work here.
> if you have any plots/diagrams/screenshots/tables, please attach them here.

As discussed in https://huggingface.co/docs/transformers/main_classes/deepspeed#getting-the-model-weights-out, I think getting fp16 state dict is essential for saving memory.

I added an arg to control the precision of state dict of Gemini.

## 💥 Checklist before requesting a review

- [ ] I have linked my PR to an issue ([instruction](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
- [ ] My issue clearly describes the problem/feature/proposal, with diagrams/charts/table/code if possible
- [x] I have performed a self-review of my code
- [ ] I have added thorough tests.
- [ ] I have added docstrings for all the functions/methods I implemented

## ⭐️ Do you enjoy contributing to Colossal-AI?

- [x] 🌝 Yes, I do.
- [ ] 🌚 No, I don't.

Tell us more if you don't enjoy contributing to Colossal-AI.
