### PR TITLE
[hotfix] upgrade gradio to 3.34.0

### DIFF
--- a/examples/images/diffusion/requirements.txt
+++ b/examples/images/diffusion/requirements.txt
@@ -12,7 +12,7 @@ einops==0.3.0
 transformers
 webdataset==0.2.5
 open-clip-torch==2.7.0
-gradio==3.11
+gradio==3.34.0
 lightning==1.9.0
 datasets
 colossalai


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in gradio 3.11
- [CVE-2023-25823](https://www.oscs1024.com/hd/CVE-2023-25823)


### What did I do？
Upgrade gradio from 3.11 to 3.34.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS