### PR TITLE
[hotfix] Updated c++17 compiler flags

### DIFF
--- a/examples/community/roberta/preprocessing/Makefile
+++ b/examples/community/roberta/preprocessing/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS += -O3 -Wall -shared -std=c++14 -fPIC -fdiagnostics-color
+CXXFLAGS += -O3 -Wall -shared -std=c++14 -std=c++17 -fPIC -fdiagnostics-color
 CPPFLAGS += $(shell python3 -m pybind11 --includes)
 LIBNAME = mask
 LIBEXT = $(shell python3-config --extension-suffix)

--- a/op_builder/cpu_adam.py
+++ b/op_builder/cpu_adam.py
@@ -21,12 +21,22 @@ class CPUAdamBuilder(Builder):
         return [self.csrc_abs_path("includes"), self.get_cuda_home_include()]
 
     def cxx_flags(self):
-        extra_cxx_flags = ["-std=c++14", "-lcudart", "-lcublas", "-g", "-Wno-reorder", "-fopenmp", "-march=native"]
+        extra_cxx_flags = [
+            "-std=c++14",
+            "-std=c++17",
+            "-lcudart",
+            "-lcublas",
+            "-g",
+            "-Wno-reorder",
+            "-fopenmp",
+            "-march=native",
+        ]
         return ["-O3"] + self.version_dependent_macros + extra_cxx_flags
 
     def nvcc_flags(self):
         extra_cuda_flags = [
             "-std=c++14",
+            "-std=c++17",
             "-U__CUDA_NO_HALF_OPERATORS__",
             "-U__CUDA_NO_HALF_CONVERSIONS__",
             "-U__CUDA_NO_HALF2_OPERATORS__",

--- a/op_builder/gptq.py
+++ b/op_builder/gptq.py
@@ -37,12 +37,12 @@ class GPTQBuilder(Builder):
         extra_cuda_flags = [
             "-v",
             "-std=c++14",
+            "-std=c++17",
             "-U__CUDA_NO_HALF_OPERATORS__",
             "-U__CUDA_NO_HALF_CONVERSIONS__",
             "-U__CUDA_NO_HALF2_OPERATORS__",
             "-DTHRUST_IGNORE_CUB_VERSION_CHECK",
             "-lcublas",
-            "-std=c++17",
         ]
 
         for arch in torch.cuda.get_arch_list():

--- a/op_builder/multi_head_attn.py
+++ b/op_builder/multi_head_attn.py
@@ -35,6 +35,7 @@ class MultiHeadAttnBuilder(Builder):
     def nvcc_flags(self):
         extra_cuda_flags = [
             "-std=c++14",
+            "-std=c++17",
             "-U__CUDA_NO_HALF_OPERATORS__",
             "-U__CUDA_NO_HALF_CONVERSIONS__",
             "-U__CUDA_NO_HALF2_OPERATORS__",

--- a/op_builder/scaled_masked_softmax.py
+++ b/op_builder/scaled_masked_softmax.py
@@ -25,6 +25,7 @@ class ScaledMaskedSoftmaxBuilder(Builder):
     def nvcc_flags(self):
         extra_cuda_flags = [
             "-std=c++14",
+            "-std=c++17",
             "-U__CUDA_NO_HALF_OPERATORS__",
             "-U__CUDA_NO_HALF_CONVERSIONS__",
             "-U__CUDA_NO_HALF2_OPERATORS__",


### PR DESCRIPTION
Building the extentions of ColossalAI with Pytorch 2.1 requires c++17. Related installation files are fixed to support this by adding `-std=c++17`.