### PR TITLE
[hotfix] fix for loading after_scheduler state

### DIFF
--- a/colossalai/nn/lr_scheduler/delayed.py
+++ b/colossalai/nn/lr_scheduler/delayed.py
@@ -48,6 +48,17 @@ class DelayerScheduler(_LRScheduler):
         else:
             raise NotImplementedError()
         return state_dict
+    
+    def load_state_dict(self, state_dict):
+        """Loads the schedulers state.
+
+        Args:
+            state_dict (dict): scheduler state. Should be an object returned
+                from a call to :meth:`state_dict`.
+        """
+        self.__dict__.update(state_dict)
+        if "after_scheduler_dict" in state_dict:
+            self.after_scheduler.load_state_dict(state_dict["after_scheduler_dict"])
 
     def get_lr(self):
         if self.last_epoch >= self.delay_epochs:
@@ -98,6 +109,17 @@ class WarmupScheduler(_LRScheduler):
         else:
             raise NotImplementedError()
         return state_dict
+    
+    def load_state_dict(self, state_dict):
+        """Loads the schedulers state.
+
+        Args:
+            state_dict (dict): scheduler state. Should be an object returned
+                from a call to :meth:`state_dict`.
+        """
+        self.__dict__.update(state_dict)
+        if "after_scheduler_dict" in state_dict:
+            self.after_scheduler.load_state_dict(state_dict["after_scheduler_dict"])
 
     def get_lr(self):
         if self.last_epoch >= self.warmup_epochs:
@@ -153,6 +175,17 @@ class WarmupDelayerScheduler(_LRScheduler):
         else:
             raise NotImplementedError()
         return state_dict
+    
+    def load_state_dict(self, state_dict):
+        """Loads the schedulers state.
+
+        Args:
+            state_dict (dict): scheduler state. Should be an object returned
+                from a call to :meth:`state_dict`.
+        """
+        self.__dict__.update(state_dict)
+        if "after_scheduler_dict" in state_dict:
+            self.after_scheduler.load_state_dict(state_dict["after_scheduler_dict"])
 
     def get_lr(self):
         if self.last_epoch >= self.warmup_epochs + self.delay_epochs:


### PR DESCRIPTION
## 📌 Checklist before creating the PR

- [ ] I have created an issue for this PR for traceability
- [ ] The title follows the standard format: `[doc/gemini/tensor/...]: A concise description`
- [ ] I have added relevant tags if possible for us to better distinguish different PRs


## 🚨 Issue number

> Link this PR to your issue with words like fixed to automatically close the linked issue upon merge
>
> e.g. `fixed #1234`, `closed #1234`, `resolved #1234`

related issue #5119 

## 📝 What does this PR do?

> Summarize your work here.
> if you have any plots/diagrams/screenshots/tables, please attach them here.


I have introduced a new method, load_state_dict, in the Scheduler class in colossalai/nn/lr_scheduler/delayed.py. This method enhances the scheduler's ability to reinstate its state, specifically focusing on the after_scheduler component. The key changes include:

Updating the Scheduler class with the load_state_dict method.
Ensuring the after_scheduler's state is appropriately loaded from the provided state dictionary if the after_scheduler_dict key is present.

## 💥 Checklist before requesting a review

- [ ] I have linked my PR to an issue ([instruction](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
- [ ] My issue clearly describes the problem/feature/proposal, with diagrams/charts/table/code if possible
- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests.
- [ ] I have added docstrings for all the functions/methods I implemented

## ⭐️ Do you enjoy contributing to Colossal-AI?

- [ ] 🌝 Yes, I do.
- [ ] 🌚 No, I don't.

Tell us more if you don't enjoy contributing to Colossal-AI.
