### PR TITLE
[hotfix] gemini should be able to use flash attention/fused norm when…

### DIFF
--- a/colossalai/booster/plugin/gemini_plugin.py
+++ b/colossalai/booster/plugin/gemini_plugin.py
@@ -468,10 +468,9 @@ class GeminiPlugin(DPPluginBase):
             # 2. patch sync bn or write a new on. This is relatively easy, but we need to test it.
             # model = nn.SyncBatchNorm.convert_sync_batchnorm(model, None)
 
-            # wrap the model with Gemini
-            if self.enable_tensor_parallelism:
-                shardformer = ShardFormer(self.shard_config)
-                model, _ = shardformer.optimize(model)
+            # wrap the model with Shardformer
+            shardformer = ShardFormer(self.shard_config)
+            model, _ = shardformer.optimize(model)
 
             model = GeminiDDP(
                 model,


### PR DESCRIPTION
… not using tp

## 📌 Checklist before creating the PR

- [ ] I have created an issue for this PR for traceability
- [ ] The title follows the standard format: `[doc/gemini/tensor/...]: A concise description`
- [ ] I have added relevant tags if possible for us to better distinguish different PRs


## 🚨 Issue number

> Link this PR to your issue with words like fixed to automatically close the linked issue upon merge
>
> e.g. `fixed #1234`, `closed #1234`, `resolved #1234`



## 📝 What does this PR do?

> Summarize your work here.
> if you have any plots/diagrams/screenshots/tables, please attach them here.

Let Gemini use optimizations such as FlashAttention/FusedRMSNorm when tp is not enabled

## 💥 Checklist before requesting a review

- [ ] I have linked my PR to an issue ([instruction](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
- [ ] My issue clearly describes the problem/feature/proposal, with diagrams/charts/table/code if possible
- [x] I have performed a self-review of my code
- [ ] I have added thorough tests.
- [x] I have added docstrings for all the functions/methods I implemented

## ⭐️ Do you enjoy contributing to Colossal-AI?

- [x] 🌝 Yes, I do.
- [ ] 🌚 No, I don't.

Tell us more if you don't enjoy contributing to Colossal-AI.
