### PR TITLE
[kernel] Add KV cache copy kernel during decoding 

### DIFF
--- a/colossalai/inference/modeling/layers/attention.py
+++ b/colossalai/inference/modeling/layers/attention.py
@@ -31,7 +31,7 @@ def copy_to_cache(source, cache, lengths, block_tables, type: str = "prefill"):
                 1, 2, 0
             )
     elif type == "decoding":
-        assert len(source[0]) == 1, "seq_len should be equal to 1 when decoding."
+        assert source.size(1) == 1, "seq_len should be equal to 1 when decoding."
         source = source.squeeze(1)
         slot_idx = (lengths + block_size - 1) % block_size
         for i in range(bsz):

--- a/colossalai/kernel/triton/__init__.py
+++ b/colossalai/kernel/triton/__init__.py
@@ -12,12 +12,14 @@ if HAS_TRITON:
     from .flash_decoding import flash_decoding_fwd
     from .fused_layernorm import layer_norm
     from .gptq_triton import gptq_fused_linear_triton
+    from .kvcache_copy import copy_kv_to_blocked_cache
     from .no_pad_rotary_embedding import rotary_embedding
     from .softmax import softmax
 
     __all__ = [
         "context_attention_unpadded",
         "flash_decoding_fwd",
+        "copy_kv_to_blocked_cache",
         "softmax",
         "layer_norm",
         "gptq_fused_linear_triton",

--- a/colossalai/kernel/triton/kvcache_copy.py
+++ b/colossalai/kernel/triton/kvcache_copy.py
@@ -67,7 +67,7 @@ def copy_kv_to_blocked_cache(
     # [bsz, 1, num_kv_heads, head_dim] -> [bsz, num_kv_heads, head_dim]
     k = k.squeeze(dim=1)
 
-    num_warps = triton.next_power_of_2(head_dim // 32)
+    num_warps = 8 if head_dim > 128 else 4
 
     grid = (bsz, num_kv_heads)
     _copy_to_kvcache_seqlen1_kernel[grid](

--- a/colossalai/kernel/triton/kvcache_copy.py
+++ b/colossalai/kernel/triton/kvcache_copy.py
@@ -1,0 +1,92 @@
+import torch
+import triton
+import triton.language as tl
+
+
+# Triton 2.1.0
+@triton.jit
+def _copy_to_kvcache_seqlen1_kernel(
+    KV,  # K or V
+    KVCache,  # KCache or VCache
+    BLOCK_TABLES,  # [batch_size, max_blocks_per_sequence]
+    context_lengths,  # [batch_size]
+    stride_kt,
+    stride_kh,
+    stride_kd,
+    stride_cacheb,
+    stride_cacheh,
+    stride_cached,
+    stride_cachebs,
+    stride_bts,
+    stride_btb,
+    block_size,
+    HEAD_DIM: tl.constexpr,
+):
+    cur_seq_idx = tl.program_id(0)
+    cur_kv_head_idx = tl.program_id(1)
+
+    # TODO might want to move indices calculation outside kernel
+    cur_kv_seq_len = tl.load(context_lengths + cur_seq_idx)
+    last_bt_block_idx = cur_kv_seq_len // block_size
+    block_table_ptr = BLOCK_TABLES + cur_seq_idx * stride_bts
+    block_id = tl.load(block_table_ptr + last_bt_block_idx * stride_btb)
+    offsets_in_last_block = (cur_kv_seq_len % block_size) * stride_cachebs
+    offsets_dmodel = tl.arange(0, HEAD_DIM)
+    offsets_kv = cur_seq_idx * stride_kt + cur_kv_head_idx * stride_cacheh + offsets_dmodel * stride_kd
+    kv = tl.load(KV + offsets_kv)
+    offsets_kvcache = (
+        block_id * stride_cacheb
+        + cur_kv_head_idx * stride_cacheh
+        + offsets_dmodel * stride_cached
+        + offsets_in_last_block
+    )
+    tl.store(KVCache + offsets_kvcache, kv)
+    return
+
+
+# Used with blocked kv cache.
+# Copy k or v to block k/v cache during decoding stage
+def copy_kv_to_blocked_cache(
+    k: torch.Tensor,  #  [bsz, 1, num_kv_heads, head_dim], k or v during decoding stage
+    k_cache: torch.Tensor,  # [num_blocks, num_kv_heads, head_dim, block_size], blocked k or v cache (for now, the shapes of them are the same)
+    context_lengths: torch.Tensor,  # [bsz], past kv seq len (not incorporating the current kv of length 1)
+    block_tables: torch.Tensor,  # [bsz, max_blocks_per_sequence]
+):
+    assert k.dim() == 4, "Unsupported shape of k (supposed to be used for decoding stage)"
+    assert k.size(1) == 1, "Unsupported kv seq len (supposed to be used for decoding stage)"
+    assert k.size(-1) == k_cache.size(-2), "Incompatible head dim"
+    assert k.dtype == k_cache.dtype, "Expected consistent dtype for tensor and cache."
+    bsz, _, num_kv_heads, head_dim = k.shape
+    assert context_lengths.shape[0] == block_tables.shape[0] == bsz, (
+        f"Got incompatible batch size (number of seqs):\n"
+        f"  Conext lengths bsz {context_lengths.shape[0]}, Block tables bsz {block_tables.shape[0]}, "
+        f"batch size {bsz}"
+    )
+
+    # NOTE Remind to modify if the shape of kv cahce is changed.
+    block_size = k_cache.size(-1)
+
+    # [bsz, 1, num_kv_heads, head_dim] -> [bsz, num_kv_heads, 1, head_dim]
+    k = k.squeeze(dim=1)
+
+    num_warps = head_dim // 16
+
+    grid = (bsz, num_kv_heads)
+    _copy_to_kvcache_seqlen1_kernel[grid](
+        k,
+        k_cache,
+        block_tables,
+        context_lengths,
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        k_cache.stride(2),
+        k_cache.stride(3),
+        block_tables.stride(0),
+        block_tables.stride(1),
+        block_size,
+        HEAD_DIM=head_dim,
+        num_warps=num_warps,
+    )

--- a/tests/test_infer_ops/triton/test_kvcache_copy.py
+++ b/tests/test_infer_ops/triton/test_kvcache_copy.py
@@ -35,7 +35,7 @@ def test_copy_kv_to_caches(
     torch.cuda.synchronize()
     torch.cuda.reset_peak_memory_stats()
 
-    head_dim = 4
+    head_dim = 128
     max_seq_len = block_size * max_num_blocks_per_seq
     dtype = torch.float16
     device = get_current_device()
@@ -69,9 +69,7 @@ def test_copy_kv_to_caches(
     for seq_i in range(bsz):
         ki = new_k[seq_i]
         ki = ki.squeeze()
-
         context_len_i = context_lengths[seq_i]
-
         target_block_id = block_tables[seq_i, context_len_i // block_size]
         offsets_in_block = context_len_i % block_size
         target = k_cache[target_block_id, :, :, offsets_in_block]
@@ -80,6 +78,4 @@ def test_copy_kv_to_caches(
 
 
 if __name__ == "__main__":
-    # test_copy_kv_to_caches(32, 32, 32, 16, False)
-    # test_copy_kv_to_caches(4, 4, 4, 2, True)
-    test_copy_kv_to_caches(32, 32, 8, 16, False)
+    test_copy_kv_to_caches(4, 32, 8, 16, False)

--- a/tests/test_infer_ops/triton/test_kvcache_copy.py
+++ b/tests/test_infer_ops/triton/test_kvcache_copy.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 from packaging import version
 
+from colossalai.inference.modeling.layers.attention import copy_to_cache
 from colossalai.kernel.triton import copy_kv_to_blocked_cache
 from colossalai.utils import get_current_device
 from tests.test_infer_ops.triton.kernel_utils import mock_alloc_block_table_and_kvcache, mock_alloc_single_token
@@ -15,6 +16,45 @@ except ImportError:
     print("please install triton from https://github.com/openai/triton")
 
 TRITON_CUDA_SUPPORT = version.parse(torch.version.cuda) > version.parse("11.4")
+
+
+def prepare_data(
+    bsz,
+    num_kv_heads,
+    head_dim,
+    block_size,
+    max_num_blocks_per_seq,
+    same_context_len,
+    max_seq_len,
+    device,
+    dtype=torch.float16,
+):
+    if same_context_len:
+        # context_lengths in this test records the previous kv seq len
+        # (not incorporating the current input whose seq len is 1)
+        context_lengths = torch.tensor([max_seq_len - 1 for _ in range(bsz)], dtype=torch.int32, device=device)
+    else:
+        context_lengths = torch.randint(low=1, high=max_seq_len - 1, size=(bsz,), dtype=torch.int32, device=device)
+    num_tokens = torch.sum(context_lengths).item()
+
+    kv_size = (num_tokens, 2 * num_kv_heads, head_dim)
+    kv = torch.empty(size=kv_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5)
+    k, v = torch.split(kv, [num_kv_heads, num_kv_heads], dim=-2)
+
+    cache_shape = (bsz * max_num_blocks_per_seq, num_kv_heads, head_dim, block_size)
+    k_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
+    v_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
+    # Mock allocation on block tables as well as blocked kv caches
+    block_tables = mock_alloc_block_table_and_kvcache(
+        k, v, k_cache, v_cache, context_lengths, bsz, max_num_blocks_per_seq, block_size
+    )
+    block_tables = block_tables.to(device=device)
+
+    new_k = torch.randn((bsz, 1, num_kv_heads, head_dim), dtype=dtype, device=device)
+    # mock allocating blocks for the new k/v and update block tables
+    mock_alloc_single_token(block_tables, context_lengths, block_size)
+
+    return new_k, k_cache, context_lengths, block_tables
 
 
 @pytest.mark.skipif(not (HAS_TRITON and TRITON_CUDA_SUPPORT), reason="requires triton")
@@ -40,30 +80,18 @@ def test_copy_kv_to_caches(
     dtype = torch.float16
     device = get_current_device()
 
-    if same_context_len:
-        # context_lengths in this test records the previous kv seq len
-        # (not incorporating the current input whose seq len is 1)
-        context_lengths = torch.tensor([max_seq_len - 1 for _ in range(bsz)], dtype=torch.int32, device=device)
-    else:
-        context_lengths = torch.randint(low=1, high=max_seq_len - 1, size=(bsz,), dtype=torch.int32, device=device)
-    num_tokens = torch.sum(context_lengths).item()
-
-    kv_size = (num_tokens, 2 * num_kv_heads, head_dim)
-    kv = torch.empty(size=kv_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5)
-    k, v = torch.split(kv, [num_kv_heads, num_kv_heads], dim=-2)
-
-    cache_shape = (bsz * max_num_blocks_per_seq, num_kv_heads, head_dim, block_size)
-    k_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
-    v_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
-    # Mock allocation on block tables as well as blocked kv caches
-    block_tables = mock_alloc_block_table_and_kvcache(
-        k, v, k_cache, v_cache, context_lengths, bsz, max_num_blocks_per_seq, block_size
+    new_k, k_cache, context_lengths, block_tables = prepare_data(
+        bsz,
+        num_kv_heads,
+        head_dim,
+        block_size,
+        max_num_blocks_per_seq,
+        same_context_len,
+        max_seq_len,
+        device=device,
+        dtype=dtype,
     )
-    block_tables = block_tables.to(device=device)
 
-    new_k = torch.randn((bsz, 1, num_kv_heads, head_dim), dtype=dtype, device=device)
-    # mock allocating blocks for the new k/v and update block tables
-    mock_alloc_single_token(block_tables, context_lengths, block_size)
     copy_kv_to_blocked_cache(new_k, k_cache, context_lengths, block_tables)
 
     for seq_i in range(bsz):
@@ -77,5 +105,64 @@ def test_copy_kv_to_caches(
         assert torch.equal(orig, target)
 
 
+BATCH = 4
+configs = [
+    triton.testing.Benchmark(
+        x_names=["PAST_KVLEN"],
+        x_vals=[2**i - 1 for i in range(8, 13)],
+        line_arg="provider",
+        line_vals=["torch_copy_func", "triton_copy_func"],
+        line_names=["torch_copy_func", "triton_copy_func"],
+        styles=[("red", "-"), ("blue", "-")],
+        ylabel="ms",
+        plot_name=f"kvcache_copy_decoding_stage-batch-{BATCH}",
+        args={"bsz": BATCH, "block_size": 16, "max_seq_len": 8192, "num_kv_heads": 16, "same_context_len": True},
+    )
+]
+
+
+@triton.testing.perf_report(configs)
+def benchmark_kvcache_copy(
+    provider: str,
+    bsz: int,
+    block_size: int,
+    max_seq_len: int,
+    PAST_KVLEN: int,  # maximum past kv length (unequal context lens in batch) or past kv len (equal context lens)
+    num_kv_heads: int,
+    same_context_len: bool,
+):
+    warmup = 10
+    rep = 100
+
+    head_dim = 128
+    dtype = torch.float16
+    device = get_current_device()
+
+    assert PAST_KVLEN < max_seq_len, "Assigned maximum past kv length must be smaller or equal to maximum seq len"
+
+    new_k, k_cache, context_lengths, block_tables = prepare_data(
+        bsz,
+        num_kv_heads,
+        head_dim,
+        block_size,
+        max_seq_len // block_size,
+        same_context_len,
+        PAST_KVLEN,
+        device=device,
+        dtype=dtype,
+    )
+
+    if provider == "torch_copy_func":
+        fn = lambda: copy_to_cache(new_k, k_cache, lengths=context_lengths, block_tables=block_tables, type="decoding")
+    elif provider == "triton_copy_func":
+        fn = lambda: copy_kv_to_blocked_cache(new_k, k_cache, context_lengths, block_tables)
+    else:
+        raise ValueError("Undefined provider.")
+
+    ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    return ms
+
+
 if __name__ == "__main__":
     test_copy_kv_to_caches(4, 32, 8, 16, False)
+    # benchmark_kvcache_copy.run(save_path=".")

--- a/tests/test_infer_ops/triton/test_kvcache_copy.py
+++ b/tests/test_infer_ops/triton/test_kvcache_copy.py
@@ -1,0 +1,85 @@
+import pytest
+import torch
+from packaging import version
+
+from colossalai.kernel.triton import copy_kv_to_blocked_cache
+from colossalai.utils import get_current_device
+from tests.test_infer_ops.triton.kernel_utils import mock_alloc_block_table_and_kvcache, mock_alloc_single_token
+
+try:
+    import triton  # noqa
+
+    HAS_TRITON = True
+except ImportError:
+    HAS_TRITON = False
+    print("please install triton from https://github.com/openai/triton")
+
+TRITON_CUDA_SUPPORT = version.parse(torch.version.cuda) > version.parse("11.4")
+
+
+@pytest.mark.skipif(not (HAS_TRITON and TRITON_CUDA_SUPPORT), reason="requires triton")
+@pytest.mark.parametrize("bsz", [4, 7, 32])
+@pytest.mark.parametrize("block_size", [16, 32, 64])
+@pytest.mark.parametrize("max_num_blocks_per_seq", [8, 32])
+@pytest.mark.parametrize("num_kv_heads", [16])
+@pytest.mark.parametrize("same_context_len", [True, False])
+def test_copy_kv_to_caches(
+    bsz: int,
+    block_size: int,
+    max_num_blocks_per_seq: int,
+    num_kv_heads: int,
+    same_context_len: bool,
+):
+    torch.manual_seed(123)
+    torch.cuda.empty_cache()
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+
+    head_dim = 4
+    max_seq_len = block_size * max_num_blocks_per_seq
+    dtype = torch.float16
+    device = get_current_device()
+
+    if same_context_len:
+        # context_lengths in this test records the previous kv seq len
+        # (not incorporating the current input whose seq len is 1)
+        context_lengths = torch.tensor([max_seq_len - 1 for _ in range(bsz)], dtype=torch.int32, device=device)
+    else:
+        context_lengths = torch.randint(low=1, high=max_seq_len - 1, size=(bsz,), dtype=torch.int32, device=device)
+    num_tokens = torch.sum(context_lengths).item()
+
+    kv_size = (num_tokens, 2 * num_kv_heads, head_dim)
+    kv = torch.empty(size=kv_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5)
+    k, v = torch.split(kv, [num_kv_heads, num_kv_heads], dim=-2)
+
+    cache_shape = (bsz * max_num_blocks_per_seq, num_kv_heads, head_dim, block_size)
+    k_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
+    v_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
+    # Mock allocation on block tables as well as blocked kv caches
+    block_tables = mock_alloc_block_table_and_kvcache(
+        k, v, k_cache, v_cache, context_lengths, bsz, max_num_blocks_per_seq, block_size
+    )
+    block_tables = block_tables.to(device=device)
+
+    new_k = torch.randn((bsz, 1, num_kv_heads, head_dim), dtype=dtype, device=device)
+    # mock allocating blocks for the new k/v and update block tables
+    mock_alloc_single_token(block_tables, context_lengths, block_size)
+    copy_kv_to_blocked_cache(new_k, k_cache, context_lengths, block_tables)
+
+    for seq_i in range(bsz):
+        ki = new_k[seq_i]
+        ki = ki.squeeze()
+
+        context_len_i = context_lengths[seq_i]
+
+        target_block_id = block_tables[seq_i, context_len_i // block_size]
+        offsets_in_block = context_len_i % block_size
+        target = k_cache[target_block_id, :, :, offsets_in_block]
+        orig = new_k[seq_i].squeeze(dim=0)
+        assert torch.equal(orig, target)
+
+
+if __name__ == "__main__":
+    # test_copy_kv_to_caches(32, 32, 32, 16, False)
+    # test_copy_kv_to_caches(4, 4, 4, 2, True)
+    test_copy_kv_to_caches(32, 32, 8, 16, False)


### PR DESCRIPTION
## 📌 Checklist before creating the PR

- [x] I have created an issue for this PR for traceability
- [x] The title follows the standard format: `[doc/gemini/tensor/...]: A concise description`
- [x] I have added relevant tags if possible for us to better distinguish different PRs


## 🚨 Issue number

> Link this PR to your issue with words like fixed to automatically close the linked issue upon merge
>
> e.g. `fixed #1234`, `closed #1234`, `resolved #1234`

Part of #5193 

## 📝 What does this PR do?

> Summarize your work here.
> if you have any plots/diagrams/screenshots/tables, please attach them here.

Add triton kernel for copying new k/v into the blocked kv cache (supposed to be used during decoding stage before attention). 

Pytests under `tests/test_infer_ops/` and `tests/test_infer/`

<img width="1387" alt="image" src="https://github.com/hpcaitech/ColossalAI/assets/54058983/0c129ecb-ec2e-4302-a382-7ab3406b0e4f">

Comparison between the triton version and previously implemented torch version of cache copy functions:
* constant because of the sequence length during decoding stage is always 1 and cache copy function is unrelated with past kv length.

batch size 4
<img width="847" alt="image" src="https://github.com/hpcaitech/ColossalAI/assets/54058983/7ff7793e-62b1-42de-828c-d208bfcfe740">

batch size 16
<img width="854" alt="image" src="https://github.com/hpcaitech/ColossalAI/assets/54058983/be8123e4-3f90-4b10-bc8f-5bd18d39d553">


## 💥 Checklist before requesting a review

- [x] I have linked my PR to an issue ([instruction](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
- [x] My issue clearly describes the problem/feature/proposal, with diagrams/charts/table/code if possible
- [x] I have performed a self-review of my code
- [x] I have added thorough tests.
- [ ] I have added docstrings for all the functions/methods I implemented

## ⭐️ Do you enjoy contributing to Colossal-AI?

- [x] 🌝 Yes, I do.
- [ ] 🌚 No, I don't.

Tell us more if you don't enjoy contributing to Colossal-AI.
