### PR TITLE
[kernel/fix] Performance Optimization for Decoding Kernel

### DIFF
--- a/colossalai/kernel/triton/__init__.py
+++ b/colossalai/kernel/triton/__init__.py
@@ -10,6 +10,8 @@ except ImportError:
 if HAS_TRITON:
     from .context_attn_unpad import context_attention_unpadded
     from .flash_decoding import flash_decoding_fwd
+    from .flash_decoding_utils import FDIntermTensors
+
     from .rms_layernorm import rms_layernorm
     from .gptq_triton import gptq_fused_linear_triton
     from .kvcache_copy import copy_kv_to_blocked_cache
@@ -24,4 +26,5 @@ if HAS_TRITON:
         "rms_layernorm",
         "gptq_fused_linear_triton",
         "rotary_embedding",
+        "FDIntermTensors",
     ]

--- a/colossalai/kernel/triton/__init__.py
+++ b/colossalai/kernel/triton/__init__.py
@@ -9,7 +9,7 @@ except ImportError:
 # There may exist import error even if we have triton installed.
 if HAS_TRITON:
     from .context_attn_unpad import context_attention_unpadded
-    from .flash_decoding import flash_decoding_fwd
+    from .flash_decoding import flash_decoding_attention
     from .flash_decoding_utils import FDIntermTensors
 
     from .rms_layernorm import rms_layernorm
@@ -20,7 +20,7 @@ if HAS_TRITON:
 
     __all__ = [
         "context_attention_unpadded",
-        "flash_decoding_fwd",
+        "flash_decoding_attention",
         "copy_kv_to_blocked_cache",
         "softmax",
         "rms_layernorm",

--- a/colossalai/kernel/triton/flash_decoding.py
+++ b/colossalai/kernel/triton/flash_decoding.py
@@ -269,8 +269,7 @@ def flash_decoding_attention(
         HEAD_DIM=head_dim,
     )
 
-    output = torch.empty_like(q)  # already overlapped
-    output = torch.empty((bsz, 1, num_heads, head_dim), dtype=q.dtype, device=q.device)
+    output = torch.empty((bsz, 1, num_heads, head_dim), dtype=q.dtype, device=q.device)  # already overlapped
 
     grid = (bsz, num_heads)
     _flash_decoding_fwd_reduce_kernel[grid](

--- a/colossalai/kernel/triton/flash_decoding.py
+++ b/colossalai/kernel/triton/flash_decoding.py
@@ -190,7 +190,8 @@ def flash_decoding_attention(
     mid_output: torch.Tensor,
     mid_output_lse: torch.Tensor,
     block_size: int,
-    num_kv_group: int = 1,
+    sm_scale: int,
+    kv_group_num: int = 1,
 ):
     """
     Flash decoding implemented with a blocked KV Cache (PagedAttention) during decoding stage.
@@ -227,7 +228,6 @@ def flash_decoding_attention(
     )
     # NOTE `kv_seq_len` records the (kv) sequence lengths incorporating past kv sequence lengths.
     bsz = kv_seq_len.size(0)  # e.g. the number of seqs
-    sm_scale = 1.0 / (head_dim**0.5)
 
     # NOTE BLOCK_KV could be considered as block splitting the sequence on k/v
     # For now, BLOCK_KV is supposed to be equivalent with the size of physical cache block (i.e.`block_size`)
@@ -264,7 +264,7 @@ def flash_decoding_attention(
         mid_output_lse.stride(1),
         mid_output_lse.stride(2),
         sm_scale,
-        KV_GROUPS=num_kv_group,
+        KV_GROUPS=kv_group_num,
         BLOCK_KV=block_size,
         BLOCK_SIZE=block_size,
         HEAD_DIM=head_dim,

--- a/colossalai/kernel/triton/flash_decoding.py
+++ b/colossalai/kernel/triton/flash_decoding.py
@@ -203,6 +203,7 @@ def flash_decoding_attention(
         k_cache (torch.Tensor): [num_blocks, num_kv_heads, head_dim, block_size]
         v_cache (torch.Tensor): [num_blocks, num_kv_heads, head_dim, block_size]
         kv_seq_len (torch.Tensor): [batch_size]
+            records the (kv) sequence lengths incorporating past kv sequence lengths.
         block_tables (torch.Tensor): [batch_size, max_blocks_per_sequence]
         max_seq_len_in_batch (int): Maximum sequence length in the batch.
         mid_output (torch.Tensor): [ max_bsz , num_heads, kv_max_split_num, head_dim]
@@ -228,8 +229,6 @@ def flash_decoding_attention(
         f"  assigned block_size {block_size}, k_cache block_size {k_cache.size(-1)}, "
         f"v_cache block_size {v_cache.size(-1)}"
     )
-    # NOTE `kv_seq_len` records the (kv) sequence lengths incorporating past kv sequence lengths.
-    bsz = kv_seq_len.size(0)  # e.g. the number of seqs
 
     # NOTE BLOCK_KV could be considered as block splitting the sequence on k/v
     # For now, BLOCK_KV is supposed to be equivalent with the size of physical cache block (i.e.`block_size`)

--- a/colossalai/kernel/triton/flash_decoding_utils.py
+++ b/colossalai/kernel/triton/flash_decoding_utils.py
@@ -1,0 +1,58 @@
+import torch
+
+from colossalai.context.singleton_meta import SingletonMeta
+from colossalai.utils import get_current_device
+
+
+class FDIntermTensors(metaclass=SingletonMeta):
+    """Singleton class to hold tensors used for storing intermediate values in flash-decoding.
+    For now, it holds intermediate output and logsumexp (which will be used in reduction step along kv)
+    """
+
+    def __init__(self):
+        self._tensors_initialized = False
+
+    @property
+    def is_initialized(self):
+        return self._tensors_initialized
+
+    @property
+    def mid_output(self):
+        assert self.is_initialized, "Intermediate tensors not initialized yet"
+        return self._mid_output
+
+    @property
+    def mid_output_lse(self):
+        assert self.is_initialized, "Intermediate tensors not initialized yet"
+        return self._mid_output_lse
+
+    def initialize(
+        self,
+        max_batch_size: int,
+        num_attn_heads: int,
+        kv_max_split_num: int,
+        head_dim: int,
+        dtype: torch.dtype = torch.float32,
+        device: torch.device = get_current_device(),
+    ) -> None:
+        """Initialize tensors.
+
+        Args:
+            max_batch_size (int): The maximum batch size over all the model forward.
+                This could be greater than the batch size in attention forward func when using dynamic batch size.
+            num_attn_heads (int)): Number of attention heads.
+            kv_max_split_num (int): The maximum number of blocks splitted on kv in flash-decoding algorithm.
+                **The maximum length/size of blocks splitted on kv should be the kv cache block size.**
+            head_dim (int): Head dimension.
+            dtype (torch.dtype, optional): Data type to be assigned to intermediate tensors.
+            device (torch.device, optional): Device used to initialize intermediate tensors.
+        """
+        assert not self.is_initialized, "Intermediate tensors used for Flash-Decoding have been initialized."
+
+        self._mid_output = torch.empty(
+            size=(max_batch_size, num_attn_heads, kv_max_split_num, head_dim), dtype=dtype, device=device
+        )
+        self._mid_output_lse = torch.empty(
+            size=(max_batch_size, num_attn_heads, kv_max_split_num), dtype=dtype, device=device
+        )
+        self._tensors_initialized = True

--- a/tests/test_infer_ops/triton/kernel_utils.py
+++ b/tests/test_infer_ops/triton/kernel_utils.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import torch
 from torch.nn import functional as F
 
@@ -17,6 +19,15 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     return hidden_states.reshape(bsz, num_key_value_heads * n_rep, seq_len, head_dim)
 
 
+def prepare_padding_mask(kv_lengths: torch.Tensor, bsz: int, kv_seq_len: int, device="cuda"):
+    padding_mask = torch.zeros((bsz, 1, 1, kv_seq_len), dtype=torch.float32, device=device)
+    for i in range(bsz):
+        cur_seq_len = kv_lengths[i].item()
+        assert cur_seq_len <= kv_seq_len
+        padding_mask[i, :, :, : kv_seq_len - cur_seq_len] = float("-inf")
+    return padding_mask
+
+
 # Attention calculation adapted from HuggingFace transformers repository
 # src/transformers/models/llama/modeling_llama.py
 # https://github.com/huggingface/transformers/blob/633215ba58fe5114d8c8d32e415a04600e010701/src/transformers/models/llama/modeling_llama.py#L350
@@ -31,7 +42,7 @@ def torch_attn_ref(
     num_heads: int,
     num_kv_heads: int,
     head_dim: int,
-):
+) -> torch.Tensor:
     assert q.shape[-1] == k.shape[-1] == v.shape[-1] == head_dim
 
     # repeat kv for GQA and MQA
@@ -43,7 +54,6 @@ def torch_attn_ref(
 
     qk = torch.matmul(q, k.transpose(2, 3))
     attn_scores = qk / (head_dim**0.5)
-
     assert attn_scores.shape == (bsz, num_heads, seq_len, kv_seq_len), "Invalid shape of attention scores"
     # for left-side padding
     if attention_mask.size() != (bsz, 1, seq_len, kv_seq_len):
@@ -71,7 +81,7 @@ def mock_alloc_block_table_and_kvcache(
     num_seqs: int,
     max_num_blocks_per_seq: int,
     block_size: int,
-):
+) -> torch.Tensor:
     """Allocate block tables based on provided context lengths; and copy KV to blocked KV Cache."""
     block_id = 0
     block_tables = torch.full(size=(num_seqs, max_num_blocks_per_seq), fill_value=-1, dtype=torch.int32)
@@ -96,12 +106,10 @@ def mock_alloc_block_table_and_kvcache(
     return block_tables
 
 
-def mock_alloc_single_token(block_tables: torch.Tensor, context_lengths: torch.Tensor, block_size: int):
-    """Allocate 1 token on the block table for each seqs in block tables.
-    It won't change provided context_lengths
-    """
-
-    # consider max_block_id as the last physical block allocated
+def mock_alloc_single_token(block_tables: torch.Tensor, context_lengths: torch.Tensor, block_size: int) -> None:
+    # Allocate 1 token on the block table for each seqs in block tables.
+    # It won't change provided context_lengths.
+    # Consider max_block_id as the last physical block allocated
     # NOTE It assumes all the blocks preceding this block have been allocated
     max_block_id = torch.max(block_tables).item()
     # the indices on each block table representing the cache block to be allocated one more token
@@ -120,3 +128,36 @@ def mock_alloc_single_token(block_tables: torch.Tensor, context_lengths: torch.T
     if new_block_ids.numel():
         new_block_alloc_local_indices = alloc_local_block_indices[require_new_block]
         block_tables[require_new_block, new_block_alloc_local_indices] = new_block_ids
+
+
+def generate_caches_and_block_tables(
+    k_unpad, v_unpad, kv_lengths, bsz, max_num_blocks_per_seq, block_size, dtype=torch.float16, device="cuda"
+) -> Tuple[torch.Tensor, ...]:
+    # Mock generation of k/v blocked caches and block tables from providied kv unpad and seq lengths
+    # k_unpad/v_unpad [num_total_tokens, num_kv_heads, head_dim]
+    _, num_kv_heads, head_dim = k_unpad.shape
+    cache_shape = (bsz * max_num_blocks_per_seq, num_kv_heads, head_dim, block_size)
+    k_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
+    v_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
+    # Mock allocation on block tables as well as blocked kv caches
+    block_tables = mock_alloc_block_table_and_kvcache(
+        k_unpad, v_unpad, k_cache, v_cache, kv_lengths, bsz, max_num_blocks_per_seq, block_size
+    )
+    return k_cache, v_cache, block_tables
+
+
+def convert_kv_unpad_to_padded(
+    k_unpad: torch.Tensor, kv_seq_lengths: torch.Tensor, bsz: int, max_seq_len: int
+) -> torch.Tensor:
+    # Rebuild (batched) k/v with padding to be used by torch attention
+    # input k_unpad/v_unpad [num_total_tokens, num_kv_heads, head_dim]
+    # returns k/v padded    [bsz, num_kv_heads, max_seq_len, head_dim]
+    _, num_kv_heads, head_dim = k_unpad.shape
+    k_torch = torch.zeros((bsz, max_seq_len, num_kv_heads, head_dim), dtype=k_unpad.dtype, device=k_unpad.device)
+    prev_len_sum = 0
+    for i, seq_len in enumerate(kv_seq_lengths.tolist()):
+        # left-side padding
+        k_torch[i, -seq_len:, :, :] = k_unpad[prev_len_sum : prev_len_sum + seq_len]
+        prev_len_sum += seq_len
+    k_torch = k_torch.transpose(1, 2)
+    return k_torch

--- a/tests/test_infer_ops/triton/kernel_utils.py
+++ b/tests/test_infer_ops/triton/kernel_utils.py
@@ -21,9 +21,9 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
 # src/transformers/models/llama/modeling_llama.py
 # https://github.com/huggingface/transformers/blob/633215ba58fe5114d8c8d32e415a04600e010701/src/transformers/models/llama/modeling_llama.py#L350
 def torch_attn_ref(
-    q: torch.Tensor,  # [bsz, seq_len, num_heads, head_dim]
-    k: torch.Tensor,  # [bsz, kv_seq_len, num_heads, head_dim]
-    v: torch.Tensor,  # [bsz, kv_seq_len, num_heads, head_dim]
+    q: torch.Tensor,  # [bsz, num_heads, q_len, head_dim]
+    k: torch.Tensor,  # [bsz, num_heads, kv_seq_len, head_dim]
+    v: torch.Tensor,  # [bsz, num_heads, kv_seq_len, head_dim]
     attention_mask: torch.Tensor,  # [bsz, 1, seq_len, kv_seq_len]
     bsz: int,
     seq_len: int,
@@ -33,12 +33,6 @@ def torch_attn_ref(
     head_dim: int,
 ):
     assert q.shape[-1] == k.shape[-1] == v.shape[-1] == head_dim
-    q = q.view(bsz, seq_len, num_heads, head_dim)
-    k = k.view(bsz, kv_seq_len, num_kv_heads, head_dim)
-    v = v.view(bsz, kv_seq_len, num_kv_heads, head_dim)
-    q = q.transpose(1, 2)
-    k = k.transpose(1, 2)
-    v = v.transpose(1, 2)
 
     # repeat kv for GQA and MQA
     # k/v won't change if kv_group_num is 1

--- a/tests/test_infer_ops/triton/test_context_attn_unpad.py
+++ b/tests/test_infer_ops/triton/test_context_attn_unpad.py
@@ -34,9 +34,9 @@ def torch_attn_unpad(
         mask[mask == 0.0] = float("-inf")
 
         torch_attn_ref_out = torch_attn_ref(
-            q[start_idx:end_idx].unsqueeze(0),
-            k[start_idx:end_idx].unsqueeze(0),
-            v[start_idx:end_idx].unsqueeze(0),
+            q[start_idx:end_idx].unsqueeze(0).transpose(1, 2),
+            k[start_idx:end_idx].unsqueeze(0).transpose(1, 2),
+            v[start_idx:end_idx].unsqueeze(0).transpose(1, 2),
             mask,
             1,  # set bsz as 1 as we're processing sequence one by one
             seq_len,

--- a/tests/test_infer_ops/triton/test_context_attn_unpad.py
+++ b/tests/test_infer_ops/triton/test_context_attn_unpad.py
@@ -4,7 +4,7 @@ from packaging import version
 
 from colossalai.kernel.triton import context_attention_unpadded
 from colossalai.utils import get_current_device
-from tests.test_infer_ops.triton.kernel_utils import mock_alloc_block_table_and_kvcache, torch_attn_ref
+from tests.test_infer_ops.triton.kernel_utils import generate_caches_and_block_tables, torch_attn_ref
 
 try:
     import triton  # noqa
@@ -15,6 +15,8 @@ except ImportError:
     print("please install triton from https://github.com/openai/triton")
 
 TRITON_CUDA_SUPPORT = version.parse(torch.version.cuda) > version.parse("11.4")
+
+HEAD_DIM = 32
 
 
 def torch_attn_unpad(
@@ -74,7 +76,6 @@ def test_context_attention(
 
     num_kv_heads = num_attn_heads // kv_group_num
     assert isinstance(num_kv_heads, int) and num_kv_heads > 0, "Invalid number of kv heads."
-    head_dim = 32
     max_seq_len = max_num_blocks_per_seq * block_size
     dtype = torch.float16
     device = get_current_device()
@@ -85,28 +86,28 @@ def test_context_attention(
         context_lengths = torch.randint(low=1, high=max_seq_len, size=(bsz,), dtype=torch.int32, device=device)
     num_tokens = torch.sum(context_lengths).item()
 
-    qkv_size = (num_tokens, num_attn_heads + 2 * num_kv_heads, head_dim)
-    qkv = torch.empty(size=qkv_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5)
-    q, k, v = torch.split(qkv, [num_attn_heads, num_kv_heads, num_kv_heads], dim=-2)
+    qkv_size = (num_tokens, num_attn_heads + 2 * num_kv_heads, HEAD_DIM)
+    qkv_unpad = torch.empty(size=qkv_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5)
+    q_unpad, k_unpad, v_unpad = torch.split(qkv_unpad, [num_attn_heads, num_kv_heads, num_kv_heads], dim=-2)
 
-    cache_shape = (bsz * max_num_blocks_per_seq, num_kv_heads, head_dim, block_size)
-    k_cache_torch = torch.zeros(size=cache_shape, dtype=dtype, device=device)
-    k_cache_triton = torch.zeros_like(k_cache_torch)
-    v_cache_torch = torch.zeros(size=cache_shape, dtype=dtype, device=device)
-    v_cache_triton = torch.zeros_like(v_cache_torch)
-
-    # Mock allocation on block tables
-    block_tables = mock_alloc_block_table_and_kvcache(
-        k, v, k_cache_torch, v_cache_torch, context_lengths, bsz, max_num_blocks_per_seq, block_size
+    k_cache_ref, v_cache_ref, block_tables = generate_caches_and_block_tables(
+        k_unpad, v_unpad, context_lengths, bsz, max_num_blocks_per_seq, block_size, dtype, device
     )
     block_tables = block_tables.to(device=device)
+    k_cache_triton = torch.zeros_like(k_cache_ref)
+    v_cache_triton = torch.zeros_like(v_cache_ref)
+
     out_triton = context_attention_unpadded(
-        q, k, v, k_cache_triton, v_cache_triton, context_lengths, block_tables, block_size
+        q_unpad, k_unpad, v_unpad, k_cache_triton, v_cache_triton, context_lengths, block_tables, block_size
     )
 
-    out_torch = torch_attn_unpad(q, k, v, context_lengths, num_attn_heads, num_kv_heads)
+    out_torch = torch_attn_unpad(q_unpad, k_unpad, v_unpad, context_lengths, num_attn_heads, num_kv_heads)
 
     assert out_torch.shape == out_triton.shape
-    assert torch.allclose(out_torch, out_triton, atol=1e-3, rtol=1e-4)
-    assert torch.allclose(k_cache_torch, k_cache_triton)
-    assert torch.allclose(v_cache_torch, v_cache_triton)
+    assert torch.allclose(out_torch, out_triton, atol=1e-3)
+    assert torch.equal(k_cache_ref, k_cache_triton)
+    assert torch.equal(v_cache_ref, v_cache_triton)
+
+
+if __name__ == "__main__":
+    test_context_attention(4, 32, 8, 16, 1, True)

--- a/tests/test_infer_ops/triton/test_decoding_attn.py
+++ b/tests/test_infer_ops/triton/test_decoding_attn.py
@@ -4,7 +4,12 @@ from packaging import version
 
 from colossalai.kernel.triton import flash_decoding_attention
 from colossalai.utils import get_current_device
-from tests.test_infer_ops.triton.kernel_utils import mock_alloc_block_table_and_kvcache, torch_attn_ref
+from tests.test_infer_ops.triton.kernel_utils import (
+    convert_kv_unpad_to_padded,
+    generate_caches_and_block_tables,
+    prepare_padding_mask,
+    torch_attn_ref,
+)
 
 try:
     import triton  # noqa
@@ -20,13 +25,33 @@ Q_LEN = 1
 HEAD_DIM = 128
 
 
-def prepare_padding_mask(kv_lengths: torch.Tensor, bsz: int, max_seq_len: int, device="cuda"):
-    padding_mask = torch.zeros((bsz, 1, 1, max_seq_len), dtype=torch.float32, device=device)
-    for i in range(bsz):
-        cur_seq_len = kv_lengths[i].item()
-        assert cur_seq_len <= max_seq_len
-        padding_mask[i, :, :, : max_seq_len - cur_seq_len] = float("-inf")
-    return padding_mask
+def prepare_data(
+    bsz: int,
+    num_attn_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    same_context_len: bool,
+    q_len: int,
+    max_kv_seq_len: int,
+    dtype=torch.float16,
+    device="cuda",
+):
+    # Use the provided maximum sequence length for each sequence when testing with teh same context length,
+    # otherwise generate random context lengths.
+    kv_lengths = (
+        torch.tensor([max_kv_seq_len for _ in range(bsz)], dtype=torch.int32, device=device)
+        if same_context_len
+        else torch.randint(low=1, high=max_kv_seq_len, size=(bsz,), dtype=torch.int32, device=device)
+    )
+    num_tokens = torch.sum(kv_lengths).item()
+
+    q_size = (bsz, q_len, num_attn_heads, head_dim)
+    q = torch.empty(size=q_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5).transpose(1, 2)
+    kv_size = (num_tokens, 2 * num_kv_heads, head_dim)
+    kv_unpad = torch.empty(size=kv_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5)
+    k_unpad, v_unpad = torch.split(kv_unpad, [num_kv_heads, num_kv_heads], dim=-2)
+
+    return q, k_unpad, v_unpad, kv_lengths
 
 
 @pytest.mark.skipif(not (HAS_TRITON and TRITON_CUDA_SUPPORT), reason="requires triton")
@@ -55,31 +80,15 @@ def test_flash_decoding(
     dtype = torch.float16
     device = get_current_device()
 
-    # Use the provided maximum sequence length for each sequence when testing with teh same context length,
-    # otherwise generate random context lengths.
-    context_lengths = (
-        torch.tensor([max_seq_len for _ in range(bsz)], dtype=torch.int32, device=device)
-        if same_context_len
-        else torch.randint(low=1, high=max_seq_len, size=(bsz,), dtype=torch.int32, device=device)
+    q, k_unpad, v_unpad, kv_seq_lengths = prepare_data(
+        bsz, num_attn_heads, num_kv_heads, HEAD_DIM, same_context_len, Q_LEN, max_seq_len, dtype, device
     )
-    num_tokens = torch.sum(context_lengths).item()
-
-    q_size = (bsz, Q_LEN, num_attn_heads, HEAD_DIM)
-    q = torch.empty(size=q_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5).transpose(1, 2)
-    kv_unpad_size = (num_tokens, 2 * num_kv_heads, HEAD_DIM)
-    kv_unpad = torch.empty(size=kv_unpad_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5)
-    k_unpad, v_unpad = torch.split(kv_unpad, [num_kv_heads, num_kv_heads], dim=-2)
-
-    cache_shape = (bsz * max_num_blocks_per_seq, num_kv_heads, HEAD_DIM, block_size)
-    k_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
-    v_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
-    # Mock allocation on block tables as well as blocked kv caches
-    block_tables = mock_alloc_block_table_and_kvcache(
-        k_unpad, v_unpad, k_cache, v_cache, context_lengths, bsz, max_num_blocks_per_seq, block_size
+    k_cache, v_cache, block_tables = generate_caches_and_block_tables(
+        k_unpad, v_unpad, kv_seq_lengths, bsz, max_num_blocks_per_seq, block_size, dtype, device
     )
     block_tables = block_tables.to(device=device)
     # The maximum sequence length in the batch (if context lengths randomly generated)
-    max_seq_len_in_b = context_lengths.max().item()
+    max_seq_len_in_b = kv_seq_lengths.max().item()
     # The maximum block length splitted on kv should be the kv cache block size
     kv_max_split_num = (max_seq_len_in_b + block_size - 1) // block_size
     mid_output = torch.empty(
@@ -91,7 +100,7 @@ def test_flash_decoding(
         q,
         k_cache,
         v_cache,
-        context_lengths,
+        kv_seq_lengths,
         block_tables,
         block_size,
         max_seq_len_in_b,
@@ -101,20 +110,9 @@ def test_flash_decoding(
         kv_group_num=kv_group_num,
     )  # [bsz, 1, num_heads, head_dim]
 
-    # rebuild (batched) kv with padding for torch attention
-    # q   [bsz, num_heads, q_len, head_dim]
-    # k/v [bsz, max_seq_len_in_b, num_kv_heads, head_dim]
-    k_torch = torch.zeros((bsz, max_seq_len_in_b, num_kv_heads, HEAD_DIM), dtype=k_unpad.dtype, device=k_unpad.device)
-    v_torch = torch.zeros_like(k_torch)
-    prev_len_sum = 0
-    for i, seq_len in enumerate(context_lengths.tolist()):
-        # left-side padding
-        k_torch[i, -seq_len:, :, :] = k_unpad[prev_len_sum : prev_len_sum + seq_len]
-        v_torch[i, -seq_len:, :, :] = v_unpad[prev_len_sum : prev_len_sum + seq_len]
-        prev_len_sum += seq_len
-    torch_padding_mask = prepare_padding_mask(context_lengths, bsz, max_seq_len_in_b, q.device)
-    k_torch = k_torch.transpose(1, 2)
-    v_torch = v_torch.transpose(1, 2)
+    k_torch = convert_kv_unpad_to_padded(k_unpad, kv_seq_lengths, bsz, max_seq_len_in_b)
+    v_torch = convert_kv_unpad_to_padded(v_unpad, kv_seq_lengths, bsz, max_seq_len_in_b)
+    torch_padding_mask = prepare_padding_mask(kv_seq_lengths, bsz, max_seq_len_in_b, q.device)
     out_torch = torch_attn_ref(
         q, k_torch, v_torch, torch_padding_mask, bsz, 1, max_seq_len_in_b, num_attn_heads, num_kv_heads, HEAD_DIM
     )
@@ -126,10 +124,12 @@ def test_flash_decoding(
 BATCH = 16
 BLOCK_SIZE = 32
 SAME_LEN = True
+WARM_UPS = 10
+REPS = 100
 configs = [
     triton.testing.Benchmark(
         x_names=["KV_LEN"],
-        x_vals=[2**i for i in range(8, 16)],
+        x_vals=[2**i for i in range(8, 14)],
         # x_vals=[x for x in range(256, 8192, 256)],
         line_arg="provider",
         line_vals=["torch", "triton"],
@@ -151,11 +151,9 @@ def bench_kernel(
     kv_group_num: int,
     same_context_len: bool,
 ):
-    warmup = 10
-    rep = 100
-
     num_attn_heads = 16
     max_num_blocks_per_seq = triton.cdiv(KV_LEN, block_size)
+    max_seq_len = block_size * max_num_blocks_per_seq
 
     num_kv_heads = num_attn_heads // kv_group_num
     assert isinstance(num_kv_heads, int) and num_kv_heads > 0, "Invalid number of kv heads."
@@ -163,51 +161,25 @@ def bench_kernel(
     dtype = torch.float16
     device = get_current_device()
 
-    kv_lengths = (
-        torch.tensor([KV_LEN for _ in range(bsz)], dtype=torch.int32, device=device)
-        if same_context_len
-        else torch.randint(low=1, high=KV_LEN, size=(bsz,), dtype=torch.int32, device=device)
+    q, k_unpad, v_unpad, kv_lengths = prepare_data(
+        bsz, num_attn_heads, num_kv_heads, HEAD_DIM, same_context_len, Q_LEN, max_seq_len, dtype, device
     )
-    num_tokens = torch.sum(kv_lengths).item()
-
-    q_size = (bsz, Q_LEN, num_attn_heads, HEAD_DIM)
-    q = torch.empty(size=q_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5).transpose(1, 2)
-    kv_size = (num_tokens, 2 * num_kv_heads, HEAD_DIM)
-    kv = torch.empty(size=kv_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5)
-    k, v = torch.split(kv, [num_kv_heads, num_kv_heads], dim=-2)
-
-    cache_shape = (bsz * max_num_blocks_per_seq, num_kv_heads, HEAD_DIM, block_size)
-    k_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
-    v_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
-    # Mock allocation on block tables as well as blocked kv caches
-    block_tables = mock_alloc_block_table_and_kvcache(
-        k, v, k_cache, v_cache, kv_lengths, bsz, max_num_blocks_per_seq, block_size
-    )
-    block_tables = block_tables.to(device=device)
-
     max_seq_len_in_b = kv_lengths.max().item()  # for random lengths
 
     quantiles = [0.5, 0.2, 0.8]
     if provider == "torch":
-        # rebuild (batched) kv with padding for torch attention
-        # q   [bsz, num_heads, q_len, head_dim]
-        # k/v [bsz, max_seq_len_in_b, num_kv_heads, head_dim]
-        k_torch = torch.zeros((bsz, max_seq_len_in_b, num_kv_heads, HEAD_DIM), dtype=k.dtype, device=k.device)
-        v_torch = torch.zeros_like(k_torch)
-        prev_len_sum = 0
-        for i, seq_len in enumerate(kv_lengths.tolist()):
-            # mock left-side padding
-            k_torch[i, -seq_len:, :, :] = k[prev_len_sum : prev_len_sum + seq_len]
-            v_torch[i, -seq_len:, :, :] = v[prev_len_sum : prev_len_sum + seq_len]
-            prev_len_sum += seq_len
+        k_torch = convert_kv_unpad_to_padded(k_unpad, kv_lengths, bsz, max_seq_len_in_b)
+        v_torch = convert_kv_unpad_to_padded(v_unpad, kv_lengths, bsz, max_seq_len_in_b)
         torch_padding_mask = prepare_padding_mask(kv_lengths, bsz, max_seq_len_in_b, q.device)
-        k_torch = k_torch.transpose(1, 2)
-        v_torch = v_torch.transpose(1, 2)
         fn = lambda: torch_attn_ref(
             q, k_torch, v_torch, torch_padding_mask, bsz, 1, max_seq_len_in_b, num_attn_heads, num_kv_heads, HEAD_DIM
         )
-        ms, min_ms, max_ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep, quantiles=quantiles)
+        ms, min_ms, max_ms = triton.testing.do_bench(fn, warmup=WARM_UPS, rep=REPS, quantiles=quantiles)
     if provider == "triton":
+        k_cache, v_cache, block_tables = generate_caches_and_block_tables(
+            k_unpad, v_unpad, kv_lengths, bsz, max_num_blocks_per_seq, block_size, dtype, device
+        )
+        block_tables = block_tables.to(device=device)
         # the maximum block length splitted on kv should be the kv cache block size
         kv_max_split_num = (max_seq_len_in_b + block_size - 1) // block_size
         mid_output = torch.empty(
@@ -228,7 +200,7 @@ def bench_kernel(
             sm_scale=sm_scale,
             kv_group_num=kv_group_num,
         )  # [bsz, 1, num_heads, head_dim]
-        ms, min_ms, max_ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep, quantiles=quantiles)
+        ms, min_ms, max_ms = triton.testing.do_bench(fn, warmup=WARM_UPS, rep=REPS, quantiles=quantiles)
 
     return ms, min_ms, max_ms
 

--- a/tests/test_infer_ops/triton/test_decoding_attn.py
+++ b/tests/test_infer_ops/triton/test_decoding_attn.py
@@ -93,10 +93,10 @@ def test_flash_decoding(
         v_cache,
         context_lengths,
         block_tables,
+        block_size,
         max_seq_len_in_b,
         mid_output,
         mid_output_lse,
-        block_size=block_size,
         sm_scale=sm_scale,
         kv_group_num=kv_group_num,
     )  # [bsz, 1, num_heads, head_dim]
@@ -221,10 +221,10 @@ def bench_kernel(
             v_cache,
             kv_lengths,
             block_tables,
+            block_size,
             max_seq_len_in_b,
             mid_output,
             mid_output_lse,
-            block_size=block_size,
             sm_scale=sm_scale,
             kv_group_num=kv_group_num,
         )  # [bsz, 1, num_heads, head_dim]

--- a/tests/test_infer_ops/triton/test_decoding_attn.py
+++ b/tests/test_infer_ops/triton/test_decoding_attn.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 from packaging import version
 
-from colossalai.kernel.triton import flash_decoding_fwd
+from colossalai.kernel.triton import flash_decoding_attention
 from colossalai.utils import get_current_device
 from tests.test_infer_ops.triton.kernel_utils import mock_alloc_block_table_and_kvcache, torch_attn_ref
 
@@ -94,7 +94,7 @@ def test_flash_decoding(
     )
     mid_output_lse = torch.empty(size=(bsz, num_attn_heads, kv_max_split_num), dtype=torch.float32, device=q.device)
 
-    out_triton = flash_decoding_fwd(
+    out_triton = flash_decoding_attention(
         q,
         k_cache,
         v_cache,

--- a/tests/test_infer_ops/triton/test_decoding_attn.py
+++ b/tests/test_infer_ops/triton/test_decoding_attn.py
@@ -17,22 +17,13 @@ except ImportError:
 TRITON_CUDA_SUPPORT = version.parse(torch.version.cuda) > version.parse("11.4")
 
 
-def torch_decoding(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, context_lengths: torch.Tensor):
-    assert context_lengths.dim() == 1, "context_lengths should be a 1D tensor"
-    assert q.size(1) == 1, "Only used for decoding"
-    assert k.shape == v.shape
-
-    bsz, _, num_heads, head_dim = q.shape
-    _, kv_seq_len, num_kv_heads, _ = k.shape
-    assert num_heads % num_kv_heads == 0, "Invalid kv heads and attention heads."
-    padding_mask = torch.zeros((bsz, 1, 1, kv_seq_len), dtype=torch.float32, device=q.device)
+def prepare_padding_mask(kv_lengths: torch.Tensor, bsz: int, max_seq_len: int, device="cuda"):
+    padding_mask = torch.zeros((bsz, 1, 1, max_seq_len), dtype=torch.float32, device=device)
     for i in range(bsz):
-        cur_seq_len = context_lengths[i].item()
-        assert cur_seq_len <= kv_seq_len
-        padding_mask[i, :, :, : kv_seq_len - cur_seq_len] = float("-inf")
-
-    out = torch_attn_ref(q, k, v, padding_mask, bsz, 1, kv_seq_len, num_heads, num_kv_heads, head_dim)
-    return out
+        cur_seq_len = kv_lengths[i].item()
+        assert cur_seq_len <= max_seq_len
+        padding_mask[i, :, :, : max_seq_len - cur_seq_len] = float("-inf")
+    return padding_mask
 
 
 @pytest.mark.skipif(not (HAS_TRITON and TRITON_CUDA_SUPPORT), reason="requires triton")
@@ -121,7 +112,124 @@ def test_flash_decoding(
         v_torch[i, -seq_len:, :, :] = v[prev_len_sum : prev_len_sum + seq_len]
         prev_len_sum += seq_len
     # k/v [bsz, max_seq_len, num_kv_heads, head_dim]
-    out_torch = torch_decoding(q, k_torch, v_torch, context_lengths)
+    torch_padding_mask = prepare_padding_mask(context_lengths, bsz, k_torch.size(1), q.device)
+    out_torch = torch_attn_ref(
+        q, k_torch, v_torch, torch_padding_mask, bsz, 1, k_torch.size(1), num_attn_heads, num_kv_heads, head_dim
+    )
 
     assert out_torch.shape == out_triton.shape
     assert torch.allclose(out_torch, out_triton, atol=1e-3, rtol=1e-4)
+
+
+BATCH = 16
+BLOCK_SIZE = 32
+SAME_LEN = True
+configs = [
+    triton.testing.Benchmark(
+        x_names=["PAST_KVLEN"],
+        x_vals=[2**i - 1 for i in range(8, 16)],
+        line_arg="provider",
+        line_vals=["torch", "triton"],
+        line_names=["torch", "triton"],
+        styles=[("red", "-"), ("blue", "-")],
+        ylabel="ms",
+        plot_name=f"decoding-block_size-{BLOCK_SIZE}-batch{BATCH}",
+        args={"bsz": BATCH, "block_size": BLOCK_SIZE, "same_context_len": SAME_LEN, "kv_group_num": 1},
+    )
+]
+
+
+@triton.testing.perf_report(configs)
+def bench_kernel(
+    bsz,
+    PAST_KVLEN,
+    provider,
+    block_size: int,
+    kv_group_num: int,
+    same_context_len: bool,
+):
+    warmup = 10
+    rep = 100
+
+    num_attn_heads = 16
+    max_num_blocks_per_seq = max(32, triton.cdiv(PAST_KVLEN + 1, block_size))
+
+    num_kv_heads = num_attn_heads // kv_group_num
+    assert isinstance(num_kv_heads, int) and num_kv_heads > 0, "Invalid number of kv heads."
+    q_len = 1
+    head_dim = 128
+    max_seq_len = block_size * max_num_blocks_per_seq
+    dtype = torch.float16
+    device = get_current_device()
+
+    if same_context_len:
+        past_kv_lengths = torch.tensor([PAST_KVLEN for _ in range(bsz)], dtype=torch.int32, device=device)
+    else:
+        past_kv_lengths = torch.randint(low=1, high=PAST_KVLEN, size=(bsz,), dtype=torch.int32, device=device)
+
+    kv_lengths = past_kv_lengths + 1
+    num_tokens = torch.sum(kv_lengths).item()
+
+    q_size = (bsz, q_len, num_attn_heads, head_dim)
+    q = torch.empty(size=q_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5)
+    kv_size = (num_tokens, 2 * num_kv_heads, head_dim)
+    kv = torch.empty(size=kv_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5)
+    k, v = torch.split(kv, [num_kv_heads, num_kv_heads], dim=-2)
+
+    cache_shape = (bsz * max_num_blocks_per_seq, num_kv_heads, head_dim, block_size)
+    k_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
+    v_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
+    # Mock allocation on block tables as well as blocked kv caches
+    block_tables = mock_alloc_block_table_and_kvcache(
+        k, v, k_cache, v_cache, kv_lengths, bsz, max_num_blocks_per_seq, block_size
+    )
+    block_tables = block_tables.to(device=device)
+
+    q = q.view(bsz, q_len, num_attn_heads, head_dim)
+
+    if provider == "torch":
+        # rebuild (batched) kv with padding for torch attention
+        # q   [bsz, 1, num_heads, head_dim]
+        # k/v [num_tokens, num_kv_heads, head_dim]
+        max_seq_len = kv_lengths.max().item()
+        k_torch = torch.zeros((bsz, max_seq_len, num_kv_heads, head_dim), dtype=k.dtype, device=k.device)
+        v_torch = torch.zeros_like(k_torch)
+        prev_len_sum = 0
+        for i, seq_len in enumerate(kv_lengths.tolist()):
+            # mock left-side padding
+            k_torch[i, -seq_len:, :, :] = k[prev_len_sum : prev_len_sum + seq_len]
+            v_torch[i, -seq_len:, :, :] = v[prev_len_sum : prev_len_sum + seq_len]
+            prev_len_sum += seq_len
+        # k/v [bsz, max_seq_len, num_kv_heads, head_dim]
+        torch_padding_mask = prepare_padding_mask(kv_lengths, bsz, k_torch.size(1), q.device)
+        fn = lambda: torch_attn_ref(
+            q, k_torch, v_torch, torch_padding_mask, bsz, 1, k_torch.size(1), num_attn_heads, num_kv_heads, head_dim
+        )
+    elif provider == "triton":
+        max_seq_len = kv_lengths.max().item()
+        # the maximum block length splitted on kv should be the kv cache block size
+        kv_max_split_num = (max_seq_len + block_size - 1) // block_size
+        mid_output = torch.empty(
+            size=(bsz, num_attn_heads, kv_max_split_num, head_dim), dtype=torch.float32, device=q.device
+        )
+        mid_output_lse = torch.empty(size=(bsz, num_attn_heads, kv_max_split_num), dtype=torch.float32, device=q.device)
+        fn = lambda: flash_decoding_attention(
+            q,
+            k_cache,
+            v_cache,
+            kv_lengths,
+            block_tables,
+            max_seq_len,
+            mid_output,
+            mid_output_lse,
+            block_size,
+            kv_group_num,
+        ).unsqueeze(1)
+
+    ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    return ms
+
+
+if __name__ == "__main__":
+    # test_flash_decoding(16, 32, 32, 16, 1, True)
+    bench_kernel.run(save_path=".", print_data=True)

--- a/tests/test_infer_ops/triton/test_decoding_attn.py
+++ b/tests/test_infer_ops/triton/test_decoding_attn.py
@@ -16,6 +16,9 @@ except ImportError:
 
 TRITON_CUDA_SUPPORT = version.parse(torch.version.cuda) > version.parse("11.4")
 
+Q_LEN = 1
+HEAD_DIM = 128
+
 
 def prepare_padding_mask(kv_lengths: torch.Tensor, bsz: int, max_seq_len: int, device="cuda"):
     padding_mask = torch.zeros((bsz, 1, 1, max_seq_len), dtype=torch.float32, device=device)
@@ -48,12 +51,12 @@ def test_flash_decoding(
 
     num_kv_heads = num_attn_heads // kv_group_num
     assert isinstance(num_kv_heads, int) and num_kv_heads > 0, "Invalid number of kv heads."
-    q_len = 1
-    head_dim = 128
     max_seq_len = block_size * max_num_blocks_per_seq
     dtype = torch.float16
     device = get_current_device()
 
+    # Use the provided maximum sequence length for each sequence when testing with teh same context length,
+    # otherwise generate random context lengths.
     context_lengths = (
         torch.tensor([max_seq_len for _ in range(bsz)], dtype=torch.int32, device=device)
         if same_context_len
@@ -61,61 +64,59 @@ def test_flash_decoding(
     )
     num_tokens = torch.sum(context_lengths).item()
 
-    q_size = (bsz, q_len, num_attn_heads, head_dim)
-    q = torch.empty(size=q_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5)
-    q = q.view(bsz, q_len, num_attn_heads, head_dim)
+    q_size = (bsz, Q_LEN, num_attn_heads, HEAD_DIM)
+    q = torch.empty(size=q_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5).transpose(1, 2)
+    kv_unpad_size = (num_tokens, 2 * num_kv_heads, HEAD_DIM)
+    kv_unpad = torch.empty(size=kv_unpad_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5)
+    k_unpad, v_unpad = torch.split(kv_unpad, [num_kv_heads, num_kv_heads], dim=-2)
 
-    kv_size = (num_tokens, 2 * num_kv_heads, head_dim)
-    kv = torch.empty(size=kv_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5)
-    k, v = torch.split(kv, [num_kv_heads, num_kv_heads], dim=-2)
-
-    cache_shape = (bsz * max_num_blocks_per_seq, num_kv_heads, head_dim, block_size)
+    cache_shape = (bsz * max_num_blocks_per_seq, num_kv_heads, HEAD_DIM, block_size)
     k_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
     v_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
     # Mock allocation on block tables as well as blocked kv caches
     block_tables = mock_alloc_block_table_and_kvcache(
-        k, v, k_cache, v_cache, context_lengths, bsz, max_num_blocks_per_seq, block_size
+        k_unpad, v_unpad, k_cache, v_cache, context_lengths, bsz, max_num_blocks_per_seq, block_size
     )
     block_tables = block_tables.to(device=device)
-
-    max_seq_len = context_lengths.max().item()
-    # the maximum block length splitted on kv should be the kv cache block size
-    kv_max_split_num = (max_seq_len + block_size - 1) // block_size
+    # The maximum sequence length in the batch (if context lengths randomly generated)
+    max_seq_len_in_b = context_lengths.max().item()
+    # The maximum block length splitted on kv should be the kv cache block size
+    kv_max_split_num = (max_seq_len_in_b + block_size - 1) // block_size
     mid_output = torch.empty(
-        size=(bsz, num_attn_heads, kv_max_split_num, head_dim), dtype=torch.float32, device=q.device
+        size=(bsz, num_attn_heads, kv_max_split_num, HEAD_DIM), dtype=torch.float32, device=q.device
     )
     mid_output_lse = torch.empty(size=(bsz, num_attn_heads, kv_max_split_num), dtype=torch.float32, device=q.device)
-    sm_scale = 1.0 / (head_dim**0.5)
+    sm_scale = 1.0 / (HEAD_DIM**0.5)
     out_triton = flash_decoding_attention(
         q,
         k_cache,
         v_cache,
         context_lengths,
         block_tables,
-        max_seq_len,
+        max_seq_len_in_b,
         mid_output,
         mid_output_lse,
         block_size=block_size,
         sm_scale=sm_scale,
         kv_group_num=kv_group_num,
-    )
-    out_triton = out_triton.unsqueeze(1)  # [bsz, 1, num_heads, head_dim]
+    )  # [bsz, 1, num_heads, head_dim]
 
     # rebuild (batched) kv with padding for torch attention
-    # q   [bsz, 1, num_heads, head_dim]
-    # k/v [num_tokens, num_kv_heads, head_dim]
-    k_torch = torch.zeros((bsz, max_seq_len, num_kv_heads, head_dim), dtype=k.dtype, device=k.device)
+    # q   [bsz, num_heads, q_len, head_dim]
+    # k/v [bsz, max_seq_len_in_b, num_kv_heads, head_dim]
+    k_torch = torch.zeros((bsz, max_seq_len_in_b, num_kv_heads, HEAD_DIM), dtype=k_unpad.dtype, device=k_unpad.device)
     v_torch = torch.zeros_like(k_torch)
     prev_len_sum = 0
     for i, seq_len in enumerate(context_lengths.tolist()):
-        # mock left-side padding
-        k_torch[i, -seq_len:, :, :] = k[prev_len_sum : prev_len_sum + seq_len]
-        v_torch[i, -seq_len:, :, :] = v[prev_len_sum : prev_len_sum + seq_len]
+        # left-side padding
+        k_torch[i, -seq_len:, :, :] = k_unpad[prev_len_sum : prev_len_sum + seq_len]
+        v_torch[i, -seq_len:, :, :] = v_unpad[prev_len_sum : prev_len_sum + seq_len]
         prev_len_sum += seq_len
-    # k/v [bsz, max_seq_len, num_kv_heads, head_dim]
-    torch_padding_mask = prepare_padding_mask(context_lengths, bsz, k_torch.size(1), q.device)
+    torch_padding_mask = prepare_padding_mask(context_lengths, bsz, max_seq_len_in_b, q.device)
+    k_torch = k_torch.transpose(1, 2)
+    v_torch = v_torch.transpose(1, 2)
     out_torch = torch_attn_ref(
-        q, k_torch, v_torch, torch_padding_mask, bsz, 1, k_torch.size(1), num_attn_heads, num_kv_heads, head_dim
+        q, k_torch, v_torch, torch_padding_mask, bsz, 1, max_seq_len_in_b, num_attn_heads, num_kv_heads, HEAD_DIM
     )
 
     assert out_torch.shape == out_triton.shape
@@ -128,7 +129,7 @@ SAME_LEN = True
 configs = [
     triton.testing.Benchmark(
         x_names=["KV_LEN"],
-        x_vals=[2**i for i in range(8, 14)],
+        x_vals=[2**i for i in range(8, 12)],
         # x_vals=[x for x in range(256, 8192, 256)],
         line_arg="provider",
         line_vals=["torch", "triton"],
@@ -154,30 +155,28 @@ def bench_kernel(
     rep = 100
 
     num_attn_heads = 16
-    max_num_blocks_per_seq = max(32, triton.cdiv(KV_LEN, block_size))
+    max_num_blocks_per_seq = triton.cdiv(KV_LEN, block_size)
 
     num_kv_heads = num_attn_heads // kv_group_num
     assert isinstance(num_kv_heads, int) and num_kv_heads > 0, "Invalid number of kv heads."
-    q_len = 1
-    head_dim = 128
-    max_seq_len = block_size * max_num_blocks_per_seq
+    block_size * max_num_blocks_per_seq
     dtype = torch.float16
     device = get_current_device()
 
     kv_lengths = (
-        torch.tensor([max_seq_len for _ in range(bsz)], dtype=torch.int32, device=device)
+        torch.tensor([KV_LEN for _ in range(bsz)], dtype=torch.int32, device=device)
         if same_context_len
-        else torch.randint(low=1, high=max_seq_len, size=(bsz,), dtype=torch.int32, device=device)
+        else torch.randint(low=1, high=KV_LEN, size=(bsz,), dtype=torch.int32, device=device)
     )
     num_tokens = torch.sum(kv_lengths).item()
 
-    q_size = (bsz, q_len, num_attn_heads, head_dim)
-    q = torch.empty(size=q_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5)
-    kv_size = (num_tokens, 2 * num_kv_heads, head_dim)
+    q_size = (bsz, Q_LEN, num_attn_heads, HEAD_DIM)
+    q = torch.empty(size=q_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5).transpose(1, 2)
+    kv_size = (num_tokens, 2 * num_kv_heads, HEAD_DIM)
     kv = torch.empty(size=kv_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5)
     k, v = torch.split(kv, [num_kv_heads, num_kv_heads], dim=-2)
 
-    cache_shape = (bsz * max_num_blocks_per_seq, num_kv_heads, head_dim, block_size)
+    cache_shape = (bsz * max_num_blocks_per_seq, num_kv_heads, HEAD_DIM, block_size)
     k_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
     v_cache = torch.zeros(size=cache_shape, dtype=dtype, device=device)
     # Mock allocation on block tables as well as blocked kv caches
@@ -186,15 +185,14 @@ def bench_kernel(
     )
     block_tables = block_tables.to(device=device)
 
-    q = q.view(bsz, q_len, num_attn_heads, head_dim)
-    max_seq_len = kv_lengths.max().item()  # for random lengths
+    max_seq_len_in_b = kv_lengths.max().item()  # for random lengths
 
     quantiles = [0.5, 0.2, 0.8]
     if provider == "torch":
         # rebuild (batched) kv with padding for torch attention
-        # q   [bsz, 1, num_heads, head_dim]
-        # k/v [num_tokens, num_kv_heads, head_dim]
-        k_torch = torch.zeros((bsz, max_seq_len, num_kv_heads, head_dim), dtype=k.dtype, device=k.device)
+        # q   [bsz, num_heads, q_len, head_dim]
+        # k/v [bsz, max_seq_len_in_b, num_kv_heads, head_dim]
+        k_torch = torch.zeros((bsz, max_seq_len_in_b, num_kv_heads, HEAD_DIM), dtype=k.dtype, device=k.device)
         v_torch = torch.zeros_like(k_torch)
         prev_len_sum = 0
         for i, seq_len in enumerate(kv_lengths.tolist()):
@@ -202,39 +200,39 @@ def bench_kernel(
             k_torch[i, -seq_len:, :, :] = k[prev_len_sum : prev_len_sum + seq_len]
             v_torch[i, -seq_len:, :, :] = v[prev_len_sum : prev_len_sum + seq_len]
             prev_len_sum += seq_len
-        # k/v [bsz, max_seq_len, num_kv_heads, head_dim]
-        torch_padding_mask = prepare_padding_mask(kv_lengths, bsz, k_torch.size(1), q.device)
+        torch_padding_mask = prepare_padding_mask(kv_lengths, bsz, max_seq_len_in_b, q.device)
+        k_torch = k_torch.transpose(1, 2)
+        v_torch = v_torch.transpose(1, 2)
         fn = lambda: torch_attn_ref(
-            q, k_torch, v_torch, torch_padding_mask, bsz, 1, k_torch.size(1), num_attn_heads, num_kv_heads, head_dim
+            q, k_torch, v_torch, torch_padding_mask, bsz, 1, max_seq_len_in_b, num_attn_heads, num_kv_heads, HEAD_DIM
         )
         ms, min_ms, max_ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep, quantiles=quantiles)
     if provider == "triton":
         # the maximum block length splitted on kv should be the kv cache block size
-        kv_max_split_num = (max_seq_len + block_size - 1) // block_size
+        kv_max_split_num = (max_seq_len_in_b + block_size - 1) // block_size
         mid_output = torch.empty(
-            size=(bsz, num_attn_heads, kv_max_split_num, head_dim), dtype=torch.float32, device=q.device
+            size=(bsz, num_attn_heads, kv_max_split_num, HEAD_DIM), dtype=torch.float32, device=q.device
         )
         mid_output_lse = torch.empty(size=(bsz, num_attn_heads, kv_max_split_num), dtype=torch.float32, device=q.device)
-        sm_scale = 1.0 / (head_dim**0.5)
+        sm_scale = 1.0 / (HEAD_DIM**0.5)
         fn = lambda: flash_decoding_attention(
             q,
             k_cache,
             v_cache,
             kv_lengths,
             block_tables,
-            max_seq_len,
+            max_seq_len_in_b,
             mid_output,
             mid_output_lse,
             block_size=block_size,
             sm_scale=sm_scale,
             kv_group_num=kv_group_num,
-        ).unsqueeze(1)
-
+        )  # [bsz, 1, num_heads, head_dim]
         ms, min_ms, max_ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep, quantiles=quantiles)
 
     return ms, min_ms, max_ms
 
 
 if __name__ == "__main__":
-    test_flash_decoding(16, 32, 32, 16, 1, True)
-    # bench_kernel.run(save_path=".", print_data=True)
+    # test_flash_decoding(16, 32, 32, 16, 1, True)
+    bench_kernel.run(save_path=".", print_data=True)

--- a/tests/test_infer_ops/triton/test_decoding_attn.py
+++ b/tests/test_infer_ops/triton/test_decoding_attn.py
@@ -129,7 +129,7 @@ SAME_LEN = True
 configs = [
     triton.testing.Benchmark(
         x_names=["KV_LEN"],
-        x_vals=[2**i for i in range(8, 12)],
+        x_vals=[2**i for i in range(8, 16)],
         # x_vals=[x for x in range(256, 8192, 256)],
         line_arg="provider",
         line_vals=["torch", "triton"],
@@ -234,5 +234,5 @@ def bench_kernel(
 
 
 if __name__ == "__main__":
-    # test_flash_decoding(16, 32, 32, 16, 1, True)
-    bench_kernel.run(save_path=".", print_data=True)
+    test_flash_decoding(16, 32, 32, 16, 1, True)
+    # bench_kernel.run(save_path=".", print_data=True)


### PR DESCRIPTION
## 📌 Checklist before creating the PR

- [ ] I have created an issue for this PR for traceability
- [x] The title follows the standard format: `[doc/gemini/tensor/...]: A concise description`
- [x] I have added relevant tags if possible for us to better distinguish different PRs


## 🚨 Issue number

> Link this PR to your issue with words like fixed to automatically close the linked issue upon merge
>
> e.g. `fixed #1234`, `closed #1234`, `resolved #1234`



## 📝 What does this PR do?

> Summarize your work here.
> if you have any plots/diagrams/screenshots/tables, please attach them here.

Revise and optimize flash-decoding triton kernel which is used with block kv cache (paged attention) during decoding stage.

\* `KV_LEN` is the kv sequence length and `q_len` is always 1.
decoding-block_size-32-batch16
|   KV_LEN  |  Torch   |  Triton  |
|-----------|----------|----------|
|   256.0   | 0.122464 | 0.029888 |
|   512.0   | 0.219200 | 0.047584 |
|  1024.0   | 0.420768 | 0.082432 |
|  2048.0   | 0.818400 | 0.154176 |
|  4096.0   | 1.620720 | 0.297440 |
|  8192.0   | 3.139680 | 0.584672 |

<img width="500" alt="image" src="https://github.com/hpcaitech/ColossalAI/assets/54058983/4aa8a421-d532-49ce-8bd8-ec676179344c">  
  
decoding-block_size-64-batch16

|   KV_LEN  |  Torch   |  Triton  |
|-----------|----------|----------|
|   256.0   | 0.121184 | 0.025248 |
|   512.0   | 0.219968 | 0.041376 |
|  1024.0   | 0.421120 | 0.069376 |
|  2048.0   | 0.816448 | 0.117328 |
|  4096.0   | 1.649408 | 0.212896 |
|  8192.0   | 3.185520 | 0.403648 |

<img width="500" alt="image" src="https://github.com/hpcaitech/ColossalAI/assets/54058983/0adda2ca-c50d-4886-af14-56daf933f9fc">

<img width="1381" alt="image" src="https://github.com/hpcaitech/ColossalAI/assets/54058983/efc9386c-ee58-48ee-a06c-7328768257a3">

## 💥 Checklist before requesting a review

- [ ] I have linked my PR to an issue ([instruction](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
- [ ] My issue clearly describes the problem/feature/proposal, with diagrams/charts/table/code if possible
- [ ] I have performed a self-review of my code
- [x] I have added thorough tests.
- [x] I have added docstrings for all the functions/methods I implemented

## ⭐️ Do you enjoy contributing to Colossal-AI?

- [x] 🌝 Yes, I do.
- [ ] 🌚 No, I don't.

Tell us more if you don't enjoy contributing to Colossal-AI.
