### PR TITLE
[Inference] Accelerate Rotary embedding, aligned to vLLM

### DIFF
--- a/colossalai/kernel/triton/fused_rotary_embedding.py
+++ b/colossalai/kernel/triton/fused_rotary_embedding.py
@@ -136,7 +136,7 @@ def fused_rotary_embedding(
     q_total_tokens, q_head_num, head_dim = q.shape
     assert q.size(0) == k.size(0)
     BLOCK_HEAD = 4
-    BLOCK_SIZE = 16
+    BLOCK_SIZE = 8
     cumsum_lens = torch.cumsum(lengths, dim=0)
 
     grid = (triton.cdiv(q_head_num, BLOCK_HEAD), triton.cdiv(q_total_tokens, BLOCK_SIZE), BLOCK_SIZE)

--- a/colossalai/kernel/triton/no_pad_rotary_embedding.py
+++ b/colossalai/kernel/triton/no_pad_rotary_embedding.py
@@ -2,6 +2,22 @@ import torch
 import triton
 import triton.language as tl
 
+"""
+# Base autotune if needed
+@triton.autotune(
+    configs=[
+        triton.Config({'BLOCK_HEAD':4,"BLOCK_TOKENS":4,},num_warps=4),
+        triton.Config({'BLOCK_HEAD':4,"BLOCK_TOKENS":8,},num_warps=8),
+        triton.Config({'BLOCK_HEAD':8,"BLOCK_TOKENS":8,},num_warps=8),
+        triton.Config({'BLOCK_HEAD':4,"BLOCK_TOKENS":4,},num_warps=16),
+        triton.Config({'BLOCK_HEAD':4,"BLOCK_TOKENS":4,},num_warps=32),
+        triton.Config({'BLOCK_HEAD':16,"BLOCK_TOKENS":16,},num_warps=4),
+        triton.Config({'BLOCK_HEAD':8,"BLOCK_TOKENS":16,},num_warps=8),
+    ],
+    key=['HEAD_DIM','q_total_tokens','Q_HEAD_NUM']
+)
+"""
+
 
 @triton.jit
 def rotary_embedding_kernel(
@@ -26,43 +42,53 @@ def rotary_embedding_kernel(
     block_head_index = tl.program_id(0)
     block_token_index = tl.program_id(1)
 
-    rotary_data = q
-    HEAD_NUM = Q_HEAD_NUM
-    head_stride = q_head_stride
-    token_stride = q_token_stride
-
-    if block_token_index * BLOCK_TOKENS >= q_total_tokens:
-        block_token_index = block_token_index - tl.cdiv(q_total_tokens, BLOCK_TOKENS)
-        rotary_data = k
-        HEAD_NUM = K_HEAD_NUM
-        head_stride = k_head_stride
-        token_stride = k_token_stride
-
     tokens_range = block_token_index * BLOCK_TOKENS + tl.arange(0, BLOCK_TOKENS)
     head_range = block_head_index * BLOCK_HEAD + tl.arange(0, BLOCK_HEAD)
 
     dim_range0 = tl.arange(0, HEAD_DIM // 2)
     dim_range1 = tl.arange(HEAD_DIM // 2, HEAD_DIM)
 
-    off_data0 = (
-        tokens_range[:, None, None] * token_stride
-        + head_range[None, :, None] * head_stride
+    off_q0 = (
+        tokens_range[:, None, None] * q_token_stride
+        + head_range[None, :, None] * q_head_stride
         + dim_range0[None, None, :] * head_dim_stride
     )
-    off_data1 = (
-        tokens_range[:, None, None] * token_stride
-        + head_range[None, :, None] * head_stride
+    off_q1 = (
+        tokens_range[:, None, None] * q_token_stride
+        + head_range[None, :, None] * q_head_stride
+        + dim_range1[None, None, :] * head_dim_stride
+    )
+    off_k0 = (
+        tokens_range[:, None, None] * k_token_stride
+        + head_range[None, :, None] * k_head_stride
+        + dim_range0[None, None, :] * head_dim_stride
+    )
+    off_k1 = (
+        tokens_range[:, None, None] * k_token_stride
+        + head_range[None, :, None] * k_head_stride
         + dim_range1[None, None, :] * head_dim_stride
     )
 
-    loaded_data0 = tl.load(
-        rotary_data + off_data0,
-        mask=((head_range[None, :, None] < HEAD_NUM) & (tokens_range[:, None, None] < q_total_tokens)),
+    loaded_q0 = tl.load(
+        q + off_q0,
+        mask=((head_range[None, :, None] < Q_HEAD_NUM) & (tokens_range[:, None, None] < q_total_tokens)),
         other=0.0,
     )
-    loaded_data1 = tl.load(
-        rotary_data + off_data1,
-        mask=((head_range[None, :, None] < HEAD_NUM) & (tokens_range[:, None, None] < q_total_tokens)),
+    loaded_q1 = tl.load(
+        q + off_q1,
+        mask=((head_range[None, :, None] < Q_HEAD_NUM) & (tokens_range[:, None, None] < q_total_tokens)),
+        other=0.0,
+    )
+
+    loaded_k0 = tl.load(
+        k + off_k0,
+        mask=((head_range[None, :, None] < K_HEAD_NUM) & (tokens_range[:, None, None] < q_total_tokens)),
+        other=0.0,
+    )
+
+    loaded_k1 = tl.load(
+        k + off_k1,
+        mask=((head_range[None, :, None] < K_HEAD_NUM) & (tokens_range[:, None, None] < q_total_tokens)),
         other=0.0,
     )
 
@@ -71,19 +97,32 @@ def rotary_embedding_kernel(
     loaded_cos = tl.load(cos + off_cos_sin, mask=(tokens_range[:, None] < q_total_tokens), other=0.0)
     loaded_sin = tl.load(sin + off_cos_sin, mask=(tokens_range[:, None] < q_total_tokens), other=0.0)
 
-    out0 = loaded_data0 * loaded_cos[:, None, :] - loaded_data1 * loaded_sin[:, None, :]
-    out1 = loaded_data0 * loaded_sin[:, None, :] + loaded_data1 * loaded_cos[:, None, :]
+    out_q0 = loaded_q0 * loaded_cos[:, None, :] - loaded_q1 * loaded_sin[:, None, :]
+    out_q1 = loaded_q0 * loaded_sin[:, None, :] + loaded_q1 * loaded_cos[:, None, :]
+
+    out_k0 = loaded_k0 * loaded_cos[:, None, :] - loaded_k1 * loaded_sin[:, None, :]
+    out_k1 = loaded_k0 * loaded_sin[:, None, :] + loaded_k1 * loaded_cos[:, None, :]
 
     # concat
     tl.store(
-        rotary_data + off_data0,
-        out0,
-        mask=((head_range[None, :, None] < HEAD_NUM) & (tokens_range[:, None, None] < q_total_tokens)),
+        q + off_q0,
+        out_q0,
+        mask=((head_range[None, :, None] < Q_HEAD_NUM) & (tokens_range[:, None, None] < q_total_tokens)),
     )
     tl.store(
-        rotary_data + off_data1,
-        out1,
-        mask=((head_range[None, :, None] < HEAD_NUM) & (tokens_range[:, None, None] < q_total_tokens)),
+        q + off_q1,
+        out_q1,
+        mask=((head_range[None, :, None] < Q_HEAD_NUM) & (tokens_range[:, None, None] < q_total_tokens)),
+    )
+    tl.store(
+        k + off_k0,
+        out_k0,
+        mask=((head_range[None, :, None] < K_HEAD_NUM) & (tokens_range[:, None, None] < q_total_tokens)),
+    )
+    tl.store(
+        k + off_k1,
+        out_k1,
+        mask=((head_range[None, :, None] < K_HEAD_NUM) & (tokens_range[:, None, None] < q_total_tokens)),
     )
 
 
@@ -105,11 +144,13 @@ def rotary_embedding(
     q_total_tokens, q_head_num, head_dim = q.shape
     assert q.size(0) == k.size(0)
     BLOCK_HEAD = 4
-    BLOCK_TOKENS = 8
-    grid = (triton.cdiv(q_head_num, BLOCK_HEAD), 2 * triton.cdiv(q_total_tokens, BLOCK_TOKENS))
+    BLOCK_TOKENS = 4
+    grid = lambda META: (triton.cdiv(q_head_num, META["BLOCK_HEAD"]), triton.cdiv(q_total_tokens, META["BLOCK_TOKENS"]))
 
-    if head_dim >= 128:
-        num_warps = 8
+    if head_dim >= 256:
+        num_warps = 32
+    elif head_dim >= 128:
+        num_warps = 16
     else:
         num_warps = 4
 
@@ -144,7 +185,6 @@ def rotary_embedding(
         BLOCK_HEAD=BLOCK_HEAD,
         BLOCK_TOKENS=BLOCK_TOKENS,
         num_warps=num_warps,
-        num_stages=1,
     )
 
     return


### PR DESCRIPTION
## 📌 Checklist before creating the PR

- [ ] I have created an issue for this PR for traceability
- [x] The title follows the standard format: `[doc/gemini/tensor/...]: A concise description`
- [x] I have added relevant tags if possible for us to better distinguish different PRs


## 🚨 Issue number

> Link this PR to your issue with words like fixed to automatically close the linked issue upon merge
>
> e.g. `fixed #1234`, `closed #1234`, `resolved #1234`



## 📝 What does this PR do?

> Summarize your work here.
> if you have any plots/diagrams/screenshots/tables, please attach them here.



## 💥 Checklist before requesting a review

- [ ] I have linked my PR to an issue ([instruction](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
- [ ] My issue clearly describes the problem/feature/proposal, with diagrams/charts/table/code if possible
- [x] I have performed a self-review of my code
- [x] I have added thorough tests.
- [x] I have added docstrings for all the functions/methods I implemented

## ⭐️ Do you enjoy contributing to Colossal-AI?

- [x] 🌝 Yes, I do.
- [ ] 🌚 No, I don't.

Tell us more if you don't enjoy contributing to Colossal-AI.

Rotary update:
1. 将q,k计算合并，有一定的提升,测试精度无误差

<img width="482" alt="image" src="https://github.com/hpcaitech/ColossalAI/assets/72591262/3ac5abef-4bed-4132-a669-bfbb40315b9e">

2. rotary cos_sin copy 合并
提升一倍
<img width="482" alt="image" src="https://github.com/hpcaitech/ColossalAI/assets/72591262/be29fce2-083b-4dc6-8332-d1310a1face4">


3. Kernel调参:
Get cos sin
<img width="482" alt="image" src="https://github.com/hpcaitech/ColossalAI/assets/72591262/c5f3bd43-57da-4b43-aa82-997305e7944b">

Rotary embedding
![image](https://github.com/hpcaitech/ColossalAI/assets/72591262/e3ac7c83-eb2a-451c-a116-2784967dda44)

