### PR TITLE
[Infer] Optimize Blocked KVCache And Kernels Using It

### DIFF
--- a/colossalai/inference/modeling/layers/attention.py
+++ b/colossalai/inference/modeling/layers/attention.py
@@ -207,7 +207,7 @@ class PagedAttention:
         num_kv_heads = k.shape[-2]
         assert num_heads % num_kv_heads == 0, "num_kv_heads should be divisible by num_heads"
         num_kv_groups = num_heads // num_kv_heads
-        block_size = k_cache.shape[-1]
+        block_size = k_cache.size(-2)
         assert q.shape[0] == k.shape[0] == v.shape[0] == block_tables.shape[0]
         block_tables.shape[-1] * block_size
 

--- a/colossalai/inference/modeling/layers/attention.py
+++ b/colossalai/inference/modeling/layers/attention.py
@@ -16,7 +16,7 @@ def copy_to_cache(source, cache, lengths, block_tables, type: str = "prefill"):
             lengths: key/value lengths
             block_tables
     """
-    num_blocks, num_heads, head_size, block_size = cache.shape
+    num_blocks, num_heads, block_size, head_size = cache.shape
     bsz, max_blocks_per_seq = block_tables.shape
     needed_blocks = (lengths + block_size - 1) // block_size
 
@@ -26,17 +26,17 @@ def copy_to_cache(source, cache, lengths, block_tables, type: str = "prefill"):
             block_num = needed_blocks[i]
             token_id = 0
             for block_idx in range(block_num - 1):
-                cache[block_tables[i][block_idx]] = source[i][token_id : token_id + block_size].permute(1, 2, 0)
+                cache[block_tables[i][block_idx]] = source[i][token_id : token_id + block_size].permute(1, 0, 2)
                 token_id += block_size
-            cache[block_tables[i][block_num - 1], :, :, : seq_len - token_id] = source[i][token_id:seq_len].permute(
-                1, 2, 0
+            cache[block_tables[i][block_num - 1], :, : seq_len - token_id, :] = source[i][token_id:seq_len].permute(
+                1, 0, 2
             )
     elif type == "decoding":
         assert source.size(1) == 1, "seq_len should be equal to 1 when decoding."
         source = source.squeeze(1)
         slot_idx = (lengths + block_size - 1) % block_size
         for i in range(bsz):
-            cache[block_tables[i, needed_blocks[i] - 1], :, :, slot_idx[i]] = source[i]
+            cache[block_tables[i, needed_blocks[i] - 1], :, slot_idx[i], :] = source[i]
 
     return cache
 
@@ -46,12 +46,12 @@ def convert_kvcache(cache, lengths, block_tables, pad_id=0):
     """
     Func: convert key/value cache for calculation
 
-    Args:   cache: shape [num_blocks, num_heads, head_size, block_size]
+    Args:   cache: shape [num_blocks, num_heads, block_size, head_size]
             lengths: key/value length
             block_tables
             pad_id: padded_id
     """
-    num_blocks, num_heads, head_size, block_size = cache.shape
+    num_blocks, num_heads, block_size, head_size = cache.shape
 
     needed_blocks = (lengths + block_size - 1) // block_size
     num_remaing_tokens = lengths % block_size
@@ -62,8 +62,8 @@ def convert_kvcache(cache, lengths, block_tables, pad_id=0):
     for i in range(bsz):
         _cache = torch.cat(
             (
-                cache[block_tables[i][: needed_blocks[i] - 1]].permute((0, 3, 1, 2)).reshape(-1, num_heads, head_size),
-                cache[block_tables[i][needed_blocks[i] - 1], :, :, : num_remaing_tokens[i]].permute(2, 0, 1),
+                cache[block_tables[i][: needed_blocks[i] - 1]].permute((0, 2, 1, 3)).reshape(-1, num_heads, head_size),
+                cache[block_tables[i][needed_blocks[i] - 1], :, : num_remaing_tokens[i], :].permute(1, 0, 2),
             ),
             dim=0,
         )
@@ -127,7 +127,7 @@ class PagedAttention:
         q: torch.Tensor,  # [num_tokens, num_heads, head_size]
         k: torch.Tensor,  # [num_tokens, num_kv_heads, head_size]
         v: torch.Tensor,
-        k_cache: torch.Tensor,  # [num_blocks, num_heads, head_size, block_size]
+        k_cache: torch.Tensor,  # [num_blocks, num_heads, block_size, head_size]
         v_cache: torch.Tensor,
         context_lengths: torch.Tensor,  # [num_seqs]
         block_tables: torch.Tensor,  # [num_seqs,max_blocks_per_sequence]
@@ -142,7 +142,7 @@ class PagedAttention:
         assert num_heads % num_kv_heads == 0, "num_kv_heads should be divisible by num_heads"
         num_kv_groups = num_heads // num_kv_heads
 
-        block_size = k_cache.shape[-1]
+        block_size = k_cache.size(-2)
         bsz, max_blocks_per_sequence = block_tables.shape
         max_seq_len = max_blocks_per_sequence * block_size
         assert q.shape[-1] == k.shape[-1] == v.shape[-1]
@@ -196,7 +196,7 @@ class PagedAttention:
         q: torch.Tensor,  # [batch_size, seq_len, num_heads, head_size]
         k: torch.Tensor,  # [batch_size, seq_len, num_kv_heads, head_size]
         v: torch.Tensor,
-        k_cache: torch.Tensor,  # [num_blocks, num_heads, head_size, block_size]
+        k_cache: torch.Tensor,  # [num_blocks, num_heads, block_size, head_size]
         v_cache: torch.Tensor,
         context_lengths: torch.Tensor,  # [num_seqs]
         block_tables: torch.Tensor,  # [num_seqs,max_blocks_per_sequence]
@@ -254,7 +254,7 @@ class PagedAttention:
         q: torch.Tensor,  # [bsz, 1, num_heads, head_size]
         k: torch.Tensor,  # [bsz, 1, num_kv_heads, head_size]
         v: torch.Tensor,
-        k_cache: torch.Tensor,  # [num_blocks, num_heads, head_size, block_size]
+        k_cache: torch.Tensor,  # [num_blocks, num_heads, block_size, head_size]
         v_cache: torch.Tensor,
         lengths: torch.Tensor,  # [num_seqs]: input_lengths + output_lengths
         block_tables: torch.Tensor,  # [num_seqs,max_blocks_per_sequence]

--- a/colossalai/inference/modeling/models/nopadding_llama.py
+++ b/colossalai/inference/modeling/models/nopadding_llama.py
@@ -171,7 +171,7 @@ def llama_attn_forward(
 
     rotary_embedding(query_states, key_states, cos_sin[0], cos_sin[1])
 
-    _, _, _, block_size = k_cache.shape
+    block_size = k_cache.size(-2)
 
     if is_prompts:
         attn_output = context_attention_unpadded(

--- a/colossalai/inference/modeling/models/padding_llama.py
+++ b/colossalai/inference/modeling/models/padding_llama.py
@@ -226,7 +226,7 @@ def llama_attn_forward(
 
         rotary_embedding(query_states, key_states, cos_sin[0], cos_sin[1])
 
-        _, _, _, block_size = k_cache.shape
+        block_size = k_cache.size(-2)
 
         if is_prompts:
             attn_output = context_attention_unpadded(

--- a/tests/test_infer/test_kvcache_manager.py
+++ b/tests/test_infer/test_kvcache_manager.py
@@ -93,7 +93,7 @@ def check_cache_manager(test_config):
     assert len(cache_manager._cache_blocks) == num_blocks
     key_caches = cache_manager._kv_caches[0]  # key caches for all the blocks in all the layers
     assert len(key_caches) == num_layers
-    expected_kv_shape = (num_blocks, num_attention_heads, head_size, block_size)
+    expected_kv_shape = (num_blocks, num_attention_heads, block_size, head_size)
     assert key_caches[0].shape == expected_kv_shape
     k_cache_block0, v_cache_block0 = cache_manager.get_physical_cache(0, 0)
     expected_kv_block_shape = expected_kv_shape[1:]


### PR DESCRIPTION
## 📌 Checklist before creating the PR

- [x] I have created an issue for this PR for traceability
- [x] The title follows the standard format: `[doc/gemini/tensor/...]: A concise description`
- [ ] I have added relevant tags if possible for us to better distinguish different PRs


## 🚨 Issue number

> Link this PR to your issue with words like fixed to automatically close the linked issue upon merge
>
> e.g. `fixed #1234`, `closed #1234`, `resolved #1234`

Part of optimization described in #5323 

## 📝 What does this PR do?

> Summarize your work here.
> if you have any plots/diagrams/screenshots/tables, please attach them here.

Modification has been made on the shape of blocked kvcaches and the kernels/functions which are using the caches. 
For now we use KV Cache shape `[num_blocks, num_heads, block_size, head_size]`

Benchmark Llama:

compared with commit e8f0642f2841f6aeb6ed0e6695ff9d9ef14f198b

| in_len | out_len | bsz | Throughput <br>(tokens/sec) | 
|--------|--------|----------|----------|
| 512 | 256 | 16 | 829.26 -> 1028.02 | 
| 512 | 256 | 32 | 1311.72 -> 1689.98 | 
| 512 | 256 | 64 | 1628.61 -> 2108.73 | 
| 1024 | 256 | 16 | 706.81 -> 867.86 |
| 1024 | 256 | 32 | 857.49 -> 1128.16 | 
| 1024 | 256 | 64 | 984.66 -> 1306.82|

w/ CUDA 12.2 on H800

Related pytests:
<img width="1392" alt="image" src="https://github.com/hpcaitech/ColossalAI/assets/54058983/f2f25898-a020-4181-865a-51446dda4729">


## 💥 Checklist before requesting a review

- [x] I have linked my PR to an issue ([instruction](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
- [ ] My issue clearly describes the problem/feature/proposal, with diagrams/charts/table/code if possible
- [x] I have performed a self-review of my code
- [x] I have added thorough tests.
- [x] I have added docstrings for all the functions/methods I implemented

## ⭐️ Do you enjoy contributing to Colossal-AI?

- [x] 🌝 Yes, I do.
- [ ] 🌚 No, I don't.

Tell us more if you don't enjoy contributing to Colossal-AI.
