### PR TITLE
[shardformer] update opt model

### DIFF
--- a/colossalai/shardformer/policies/opt.py
+++ b/colossalai/shardformer/policies/opt.py
@@ -24,12 +24,6 @@ __all__ = [
 class OPTPolicy(Policy):
     def __init__(self) -> None:
         super().__init__()
-        import transformers
-        from packaging.version import Version
-
-        assert Version(transformers.__version__) <= Version(
-            "4.33.0"
-        ), "The OPT model should run on a transformers version not greater than 4.33.0."
 
     def config_sanity_check(self):
         pass


### PR DESCRIPTION
## 🚨 Issue number

- [ ] https://github.com/hpcaitech/ColossalAI/issues/5505


## 📝 What does this PR do?

[shardformer/modeling/gpt2]: Upgrade transformers from version 4.33.0 to version 4.36.0 for the opt model, including the `forward` function of the `OPT` model and remove the restrictions of policies.