### PR TITLE
[shardformer] update vit model

### DIFF
--- a/colossalai/shardformer/modeling/vit.py
+++ b/colossalai/shardformer/modeling/vit.py
@@ -20,8 +20,6 @@ def _encoder_forward(
     stage_manager: PipelineStageManager = None,
 ) -> Union[tuple, BaseModelOutput]:
     for i in range(start_idx, end_idx):
-        if output_hidden_states:
-                all_hidden_states = all_hidden_states + (hidden_states,)
         layer_module = encoder.layer[i]
 
         layer_head_mask = head_mask[i] if head_mask is not None else None

--- a/colossalai/shardformer/modeling/vit.py
+++ b/colossalai/shardformer/modeling/vit.py
@@ -14,29 +14,27 @@ def _encoder_forward(
     end_idx: int,
     hidden_states: torch.Tensor,
     head_mask: Optional[torch.Tensor] = None,
+    output_attentions: bool = False,
+    output_hidden_states: bool = False,
     return_dict: bool = True,
     stage_manager: PipelineStageManager = None,
 ) -> Union[tuple, BaseModelOutput]:
     for i in range(start_idx, end_idx):
+        if output_hidden_states:
+                all_hidden_states = all_hidden_states + (hidden_states,)
         layer_module = encoder.layer[i]
 
         layer_head_mask = head_mask[i] if head_mask is not None else None
 
         if encoder.gradient_checkpointing and encoder.training:
-
-            def create_custom_forward(module):
-                def custom_forward(*inputs):
-                    return module(*inputs, False)
-
-                return custom_forward
-
-            layer_outputs = torch.utils.checkpoint.checkpoint(
-                create_custom_forward(layer_module),
-                hidden_states,
-                layer_head_mask,
-            )
+            layer_outputs = encoder._gradient_checkpointing_func(
+                    layer_module.__call__,
+                    hidden_states,
+                    layer_head_mask,
+                    output_attentions,
+                )
         else:
-            layer_outputs = layer_module(hidden_states, layer_head_mask, False)
+            layer_outputs = layer_module(hidden_states, layer_head_mask, output_attentions)
 
         hidden_states = layer_outputs[0]
     if not stage_manager.is_last_stage():
@@ -112,6 +110,8 @@ def ViTModel_pipeline_forward(stage_manager: PipelineStageManager, stage_index: 
             end_idx=stage_index[1],
             hidden_states=hidden_states,
             head_mask=head_mask,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
             return_dict=return_dict,
             stage_manager=stage_manager,
         )


### PR DESCRIPTION
## 🚨 Issue number

- [ ] https://github.com/hpcaitech/ColossalAI/issues/5505



## 📝 What does this PR do?

[shardformer/modeling/t5]: Upgrade transformers from version 4.33.0 to version 4.36.0 for the vit model, including the `_encoder_forward` function and the `pp_forward` function.

