### PR TITLE
[shardformer] allow skipping modules that are already replaced during sharding

### DIFF
--- a/colossalai/shardformer/policies/base_policy.py
+++ b/colossalai/shardformer/policies/base_policy.py
@@ -71,9 +71,10 @@ class Policy(ABC):
     If you want to define your own policy, you can inherit from this class and overwrite the methods you want to modify.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, skip_replaced_modules: bool = False) -> None:
         self.shard_config: Optional[ShardConfig] = None
         self.model: Optional[Module] = None
+        self.skip_replaced_modules = skip_replaced_modules
 
     def set_model(self, model: nn.Module) -> None:
         r"""

--- a/colossalai/shardformer/shard/sharder.py
+++ b/colossalai/shardformer/shard/sharder.py
@@ -97,6 +97,7 @@ class ModelSharder(object):
             method_replacement (Dict[str, Callable]):  Key is the method name, value is the method for replacement
             sub_module_replacement ((List[SubModuleReplacementDescription]): The function list to get sub module shard information in policy
             include (Set[nn.Module], optional): The set of modules to keep on current device when pipeline parallel is enabled. Defaults to None
+            skip_replaced_modules (bool, optional): Whether to skip or raise an exception when the module has been replaced. Defaults to False
         """
         if (isinstance(origin_cls, str) and origin_cls == module.__class__.__name__) or (
             module.__class__ == origin_cls
@@ -175,6 +176,7 @@ class ModelSharder(object):
             org_layer (torch.nn.Module): The origin layer object to shard
             sub_module_replacement (List[SubModuleReplacementDescription]): The sub module replacement description list
             include (Set[nn.Module], optional): The set of modules to keep on current device when pipeline parallel is enabled. Defaults to None
+            skip_replaced_modules (bool, optional): Whether to skip or raise an exception when the module has been replaced. Defaults to False
         """
         for description in sub_module_replacement:
             suffix = description.suffix


### PR DESCRIPTION
## 📌 Checklist before creating the PR

- [ ] I have created an issue for this PR for traceability
- [x] The title follows the standard format: `[doc/gemini/tensor/...]: A concise description`
- [ ] I have added relevant tags if possible for us to better distinguish different PRs


## 🚨 Issue number

> Link this PR to your issue with words like fixed to automatically close the linked issue upon merge
>
> e.g. `fixed #1234`, `closed #1234`, `resolved #1234`



## 📝 What does this PR do?

> Summarize your work here.
> if you have any plots/diagrams/screenshots/tables, please attach them here.

This PR allows `ModelSharder` to skip module replacement if the target module is already replaced.
Users can change its behavior by explicitly giving `skip_replaced_modules` to their policy, and default behavior which raises an exception is not changed, though the type of exception is changed from `AssertionError` from `RuntimeError`.
This is useful when there is a usecase that needs to apply shardformer.optimizer() several times on the same model.

## 💥 Checklist before requesting a review

- [ ] I have linked my PR to an issue ([instruction](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
- [x] My issue clearly describes the problem/feature/proposal, with diagrams/charts/table/code if possible
- [x] I have performed a self-review of my code
- [ ] I have added thorough tests.
- [x] I have added docstrings for all the functions/methods I implemented

Currently no tests are added, I just did a few e2e tests and worked. Yet it is better to have tests; I would appreciate it if you could let me know which directory would be the best for this feature.

## ⭐️ Do you enjoy contributing to Colossal-AI?

- [x] 🌝 Yes, I do.
- [ ] 🌚 No, I don't.

Tell us more if you don't enjoy contributing to Colossal-AI.
