### PR TITLE
[Fix]: implement thread-safety singleton to avoid deadlock for very large-scale training scenarios

### DIFF
--- a/colossalai/context/singleton_meta.py
+++ b/colossalai/context/singleton_meta.py
@@ -1,15 +1,20 @@
 import threading
-    
+
 """
 Synchronization decorator
 """
+
+
 def synchronized(lock):
     def wrap(func):
         def synchronized_func(*args, **kwargs):
             with lock:
                 return func(*args, **kwargs)
+
         return synchronized_func
+
     return wrap
+
 
 class SingletonMeta(type):
     """

--- a/colossalai/context/singleton_meta.py
+++ b/colossalai/context/singleton_meta.py
@@ -1,5 +1,6 @@
 import threading
 
+
 class SingletonMeta(type):
     """
     Thread-safe Singleton Meta with double-checked locking.

--- a/colossalai/context/singleton_meta.py
+++ b/colossalai/context/singleton_meta.py
@@ -1,24 +1,8 @@
 import threading
 
-"""
-Synchronization decorator
-"""
-
-
-def synchronized(lock):
-    def wrap(func):
-        def synchronized_func(*args, **kwargs):
-            with lock:
-                return func(*args, **kwargs)
-
-        return synchronized_func
-
-    return wrap
-
-
 class SingletonMeta(type):
     """
-    Thread-safe Singleton Meta, and we use double-checked locking to ensure no degradation on performance
+    Thread-safe Singleton Meta with double-checked locking.
     Reference: https://en.wikipedia.org/wiki/Double-checked_locking
     """
 
@@ -26,16 +10,17 @@ class SingletonMeta(type):
     _lock = threading.Lock()
 
     def __call__(cls, *args, **kwargs):
+        # First check (without locking) for performance reasons
         if cls not in cls._instances:
-            instance = cls._locked_call(*args, **kwargs)
-            cls._instances[cls] = instance
+            # Acquire a lock before proceeding to the second check
+            with cls._lock:
+                # Second check with lock held to ensure thread safety
+                if cls not in cls._instances:
+                    instance = super().__call__(*args, **kwargs)
+                    cls._instances[cls] = instance
         else:
             assert (
                 len(args) == 0 and len(kwargs) == 0
-            ), f"{cls.__name__} is a singleton class and a instance has been created."
-        return cls._instances[cls]
+            ), f"{cls.__name__} is a singleton class and an instance has been created."
 
-    @synchronized(_lock)
-    def _locked_call(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super(SingletonMeta, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]


### PR DESCRIPTION
## 📌 Checklist before creating the PR

- [x] I have created an issue for this PR for traceability
- [x] The title follows the standard format: `[doc/gemini/tensor/...]: A concise description`
- [x] I have added relevant tags if possible for us to better distinguish different PRs
- [x] I have installed pre-commit: `pip install pre-commit && pre-commit install`


## 🚨 Issue number

None

## 📝 What does this PR do?

During very large-scale training (especially gpus numer >=1024), it would be a high probability that we get stuck when launching training processes. We found the root cause a deadlock within singleton implementation in multhreading scenarios.

## 💥 Checklist before requesting a review

- [ ] I have linked my PR to an issue ([instruction](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
- [x] My issue clearly describes the problem/feature/proposal, with diagrams/charts/table/code if possible
- [x] I have performed a self-review of my code
- [x] I have added thorough tests.
- [x] I have added docstrings for all the functions/methods I implemented

## ⭐️ Do you enjoy contributing to Colossal-AI?

- [x] 🌝 Yes, I do.
- [ ] 🌚 No, I don't.

Tell us more if you don't enjoy contributing to Colossal-AI.
