### PR TITLE
[kernel] Support New KCache Layout - Triton Kernel

### DIFF
--- a/colossalai/kernel/triton/context_attn_unpad.py
+++ b/colossalai/kernel/triton/context_attn_unpad.py
@@ -338,8 +338,8 @@ def _fwd_context_paged_attention_kernel_v2(
         X_range = tl.arange(0, KCACHE_X)
         # unroll the loop aggressively
         for split_x in tl.static_range(HEAD_DIM // KCACHE_X):
-            offsets_dmodel_x_partion = tl.arange(split_x * KCACHE_X, (split_x + 1) * KCACHE_X)
-            offsets_k = K + offset_kv + offsets_dmodel_x_partion[None, :] * stride_kd + offsets_m[:, None] * stride_kt
+            offsets_dmodel_x_partition = tl.arange(split_x * KCACHE_X, (split_x + 1) * KCACHE_X)
+            offsets_k = K + offset_kv + offsets_dmodel_x_partition[None, :] * stride_kd + offsets_m[:, None] * stride_kt
             k = tl.load(offsets_k, mask=offsets_m[:, None] < cur_seq_len, other=0.0)
             # HACK: KCache must be contiguous in order to apply the following offsets calculation
             offsets_kcache = (

--- a/colossalai/kernel/triton/flash_decoding.py
+++ b/colossalai/kernel/triton/flash_decoding.py
@@ -126,6 +126,127 @@ def _flash_decoding_fwd_kernel(
 
 # Triton 2.1.0
 @triton.jit
+def _flash_decoding_fwd_kernel_v2(
+    Q,  # [batch_size * q_len, head_num, head_dim]
+    KCache,  # [num_blocks, num_kv_heads, block_size, head_dim]
+    VCache,  # [num_blocks, num_kv_heads, head_dim//x, block_size, x]
+    block_tables,  # [batch_size, max_blocks_per_sequence]
+    mid_o,  # [batch_size * q_len, head_num, kv_split_num, head_dim]
+    mid_o_lse,  # [batch_size * q_len, head_num, kv_split_num]
+    kv_seq_len,  # [batch_size]
+    q_len,
+    batch_size,
+    kv_group_num,
+    x,
+    stride_qt,
+    stride_qh,
+    stride_qd,
+    stride_kcb,
+    stride_kch,
+    stride_kcsplit_x,
+    stride_kcs,
+    stride_kcd,
+    stride_vcb,
+    stride_vch,
+    stride_vcs,
+    stride_vcd,
+    stride_bts,
+    stride_btb,
+    stride_mid_ot,
+    stride_mid_oh,
+    stride_mid_ob,
+    stride_mid_od,
+    stride_mid_o_lset,
+    stride_mid_o_lseh,
+    stride_mid_o_lseb,
+    sm_scale,
+    BLOCK_KV: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+):
+    cur_token_idx = tl.program_id(0)
+    cur_seq_idx = cur_token_idx // q_len
+    if cur_seq_idx >= batch_size:
+        return
+    cur_token_off = (cur_token_idx % q_len) - q_len + 1
+    cur_head_idx = tl.program_id(1)
+    block_start_kv = tl.program_id(2)  # for splitting k/v
+
+    # NOTE It requires BLOCK_KV and BLOCK_SIZE to be the same
+    # TODO might want to replace with BLOCK_KV % BLOCK_SIZE == 0 (optimize BLOCK_KV as multiple of BLOCK_SIZE)
+    #      and then support calculating multiple kv cache blocks on an instance
+    tl.static_assert(BLOCK_KV == BLOCK_SIZE)
+    # get the current (kv) sequence length
+    # cur_token_off is used as a "mask" here for spec-dec during verification process
+    cur_kv_seq_len = tl.load(kv_seq_len + cur_seq_idx) + cur_token_off
+    if block_start_kv * BLOCK_KV >= cur_kv_seq_len:
+        return
+    offsets_dmodel = tl.arange(0, HEAD_DIM)
+    offsets_block = tl.arange(0, BLOCK_SIZE)
+    # block table for the current sequence
+    block_table_ptr = block_tables + cur_seq_idx * stride_bts
+    cur_block_id = tl.load(block_table_ptr + block_start_kv * stride_btb)
+    cur_occupied_size = tl.where(
+        (block_start_kv + 1) * BLOCK_SIZE <= cur_kv_seq_len, BLOCK_SIZE, cur_kv_seq_len - block_start_kv * BLOCK_SIZE
+    )
+    tl.device_assert(cur_occupied_size >= 0)
+
+    offsets_q = cur_token_idx * stride_qt + cur_head_idx * stride_qh + offsets_dmodel * stride_qd
+    q = tl.load(Q + offsets_q)
+    cur_kv_head_idx = cur_head_idx // kv_group_num
+    offset_kvcache = cur_block_id * stride_kcb + cur_kv_head_idx * stride_kch
+    offsets_k = (
+        offset_kvcache
+        + (offsets_dmodel[None, :] // x) * stride_kcsplit_x
+        + (offsets_dmodel[None, :] % x) * stride_kcd
+        + offsets_block[:, None] * stride_kcs
+    )
+    k_cur_block = tl.load(KCache + offsets_k)
+    V_block_ptr = tl.make_block_ptr(
+        base=VCache + offset_kvcache,
+        shape=(cur_occupied_size, HEAD_DIM),
+        strides=(stride_vcs, stride_vcd),
+        offsets=(0, 0),
+        block_shape=(BLOCK_SIZE, HEAD_DIM),
+        order=(0, 1),
+    )
+    v_cur_block = tl.load(V_block_ptr)
+
+    acc = tl.zeros([HEAD_DIM], dtype=tl.float32)
+    # use block size of the blocked kv cache
+    S_ij = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+    # NOTE a trick to come across triton's requirement that values in both first and second input shapes must be >= 16,
+    # Multiplying two tensors with shapes [1, d] * [d, block_size] will fail.
+    # Refer to https://github.com/openai/triton/discussions/895
+    S_ij += tl.sum(q[None, :] * k_cur_block, 1)
+    S_ij *= sm_scale
+    S_ij += tl.where(block_start_kv * BLOCK_KV + offsets_block < cur_kv_seq_len, 0, float("-inf"))
+
+    m = tl.max(S_ij, 0)
+    S_ij -= m
+    p_ij_hat = tl.exp(S_ij)
+    l = tl.sum(p_ij_hat, 0)
+    p_ij_hat = p_ij_hat.to(v_cur_block.type.element_ty)
+
+    acc += tl.sum(v_cur_block * p_ij_hat[:, None], 0)
+    acc = acc / l
+
+    offsets_mid_o = (
+        cur_token_idx * stride_mid_ot
+        + cur_head_idx * stride_mid_oh
+        + block_start_kv * stride_mid_ob
+        + offsets_dmodel * stride_mid_od
+    )
+    tl.store(mid_o + offsets_mid_o, acc)
+    offsets_mid_o_lse = (
+        cur_token_idx * stride_mid_o_lset + cur_head_idx * stride_mid_o_lseh + block_start_kv * stride_mid_o_lseb
+    )
+    # logsumexp L^(j) = m^(j) + log(l^(j))
+    tl.store(mid_o_lse + offsets_mid_o_lse, m + tl.log(l))
+
+
+# Triton 2.1.0
+@triton.jit
 def _alibi_flash_decoding_fwd_kernel(
     Q,  # [batch_size * q_len, head_num, head_dim]
     KCache,  # [num_blocks, num_kv_heads, block_size, head_dim]
@@ -324,6 +445,7 @@ def flash_decoding_attention(
     sm_scale: int = None,
     kv_group_num: int = 1,
     q_len: int = 1,  # NOTE alibi flash decoding does not support q_len > 1 at this moment.
+    use_new_kcache_layout: bool = False,
 ):
     """
     Flash decoding implemented with a blocked KV Cache (PagedAttention) during decoding stage.
@@ -349,6 +471,7 @@ def flash_decoding_attention(
         num_kv_group (int, optional): Number of key/value groups. Defaults to 1.
         q_length (int): Query length. Use for speculative decoding when `q_length` > 1 (i.e. the last n tokens).
             Defaults to 1.
+        use_new_kcache_layout (bool): Whether to use the new kcache layout. Defaults to False.
 
     Returns:
         Output tensor with shape [bsz * q_len, num_heads * head_dim]
@@ -400,13 +523,60 @@ def flash_decoding_attention(
 
     # NOTE use `triton.next_power_of_2` here to utilize the cache mechanism of triton
     # To optimize, revise batching/scheduling to batch 2^n sequences in a batch (preferred)
-    grid = (
+    grid = lambda META: (
         triton.next_power_of_2(bsz * q_len),
         num_heads,
-        triton.cdiv(triton.next_power_of_2(max_seq_len_in_batch), BLOCK_KV),
+        triton.cdiv(triton.next_power_of_2(max_seq_len_in_batch), META["BLOCK_KV"]),
     )
 
-    if alibi_slopes is not None:
+    if use_new_kcache_layout:
+        # TODO(yuanheng-zhao): Since the alibi kernel is pretty similar to the original one,
+        # the code (alibi kernel) will be refactored later to avoid code duplication, when
+        # the whole triton flow with new k cache layout has been supported and tested.
+        assert (
+            alibi_slopes is None
+        ), "Alibi Slopes will be supported with new kcache layout later when the whole triton flow is ready"
+
+        x = k_cache.shape[4]
+        _flash_decoding_fwd_kernel_v2[grid](
+            q,
+            k_cache,
+            v_cache,
+            block_tables,
+            mid_output,
+            mid_output_lse,
+            kv_seq_len,
+            q_len,
+            bsz,
+            kv_group_num,
+            x,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            k_cache.stride(0),
+            k_cache.stride(1),
+            k_cache.stride(2),
+            k_cache.stride(3),
+            k_cache.stride(4),
+            v_cache.stride(0),
+            v_cache.stride(1),
+            v_cache.stride(2),
+            v_cache.stride(3),
+            block_tables.stride(0),
+            block_tables.stride(1),
+            mid_output.stride(0),
+            mid_output.stride(1),
+            mid_output.stride(2),
+            mid_output.stride(3),
+            mid_output_lse.stride(0),
+            mid_output_lse.stride(1),
+            mid_output_lse.stride(2),
+            sm_scale,
+            BLOCK_KV=block_size,
+            BLOCK_SIZE=block_size,
+            HEAD_DIM=head_dim,
+        )
+    elif alibi_slopes is not None:
         _alibi_flash_decoding_fwd_kernel[grid](
             q,
             k_cache,

--- a/colossalai/kernel/triton/kvcache_copy.py
+++ b/colossalai/kernel/triton/kvcache_copy.py
@@ -48,12 +48,69 @@ def _copy_to_kcache_seqlen_n_kernel(
 
 
 # Triton 2.1.0
+# supports two types of cache layouts
+# 1. [num_blocks, num_kv_heads, block_size, head_dim]
+# 2. [num_blocks, num_kv_heads, head_dim // x, block_size, x]
+@triton.jit
+def _copy_to_kcache_seqlen_n_kernel_v2(
+    K,  # K or V
+    KCache,  # [num_blocks, num_kv_heads, head_dim // x, block_size, x]
+    BLOCK_TABLES,
+    seq_lengths,
+    stride_kt,
+    stride_kh,
+    stride_kd,
+    stride_kcb,
+    stride_kch,
+    stride_kcsplit_x,
+    stride_kcs,
+    stride_kcx,
+    stride_bts,
+    stride_btb,
+    block_size,
+    n_tokens,
+    HEAD_DIM: tl.constexpr,
+    KCACHE_X: tl.constexpr,
+):
+    # `n_tokens` is used to specify the number of tokens to copy for each sequence
+    # When n_tokens > 1, tokens from different sequences are packed into the first dimension of the grid,
+    #   `seq_lengths` must be the lengths of sequences counting the number of tokens to copy
+    #   E.g. if n_tokens = 5, seq_lengths = [12, 15], then the already-copied position ids are [0-6, 0-9]
+    #   for the two sequences, respectively. And the position ids to be copied are [7-11, 9-14].
+    # When n_tokens = 1, consider token idx as the sequence idx, since it's only used during regular decoding stage
+    cur_token_idx = tl.program_id(0)
+    cur_seq_idx = cur_token_idx // n_tokens
+    # `cur_token_shift` is only valid and functional when `n_tokens` > 1
+    cur_token_shift = cur_token_idx - (n_tokens * (cur_seq_idx + 1))
+    cur_kv_head_idx = tl.program_id(1)
+    split_x_idx = tl.program_id(2)
+
+    past_kv_seq_len = tl.load(seq_lengths + cur_seq_idx) + cur_token_shift
+    last_bt_block_idx = past_kv_seq_len // block_size
+    block_table_ptr = BLOCK_TABLES + cur_seq_idx * stride_bts
+    block_id = tl.load(block_table_ptr + last_bt_block_idx * stride_btb)
+    offset_last_block = past_kv_seq_len % block_size
+    offsets_dmodel = split_x_idx * KCACHE_X + tl.arange(0, KCACHE_X)
+    offsets_k = cur_token_idx * stride_kt + cur_kv_head_idx * stride_kh + offsets_dmodel * stride_kd
+    k = tl.load(K + offsets_k)
+    offsets_kcache = (
+        block_id * stride_kcb
+        + cur_kv_head_idx * stride_kch
+        + split_x_idx * stride_kcsplit_x
+        + offset_last_block * stride_kcs
+        + tl.arange(0, KCACHE_X)
+    )
+    tl.store(KCache + offsets_kcache, k)
+    return
+
+
+# Triton 2.1.0
 @triton.jit
 def _copy_to_kvcache_seqlen1_kernel(
-    K,  # K
-    V,  # V
-    KCache,  # KCache
-    VCache,  # VCache
+    K,
+    V,
+    KCache,
+    VCache,
     BLOCK_TABLES,
     context_lengths,
     stride_kt,
@@ -62,18 +119,20 @@ def _copy_to_kvcache_seqlen1_kernel(
     stride_vt,
     stride_vh,
     stride_vd,
-    stride_cachekb,
-    stride_cachekh,
-    stride_cachekbs,
-    stride_cachekd,
-    stride_cachevb,
-    stride_cachevh,
-    stride_cachevbs,
-    stride_cachevd,
+    stride_kcb,
+    stride_kch,
+    stride_kcsplit_x,
+    stride_kcs,
+    stride_kcd,
+    stride_vcb,
+    stride_vch,
+    stride_vcs,
+    stride_vcd,
     stride_bts,
     stride_btb,
     block_size,
     HEAD_DIM: tl.constexpr,
+    KCACHE_X: tl.constexpr,
 ):
     cur_seq_idx = tl.program_id(0)
     cur_kv_head_idx = tl.program_id(1)
@@ -83,33 +142,42 @@ def _copy_to_kvcache_seqlen1_kernel(
     block_table_ptr = BLOCK_TABLES + cur_seq_idx * stride_bts
     block_id = tl.load(block_table_ptr + last_bt_block_idx * stride_btb)
     offsets_in_last_block = past_kv_seq_len % block_size
-    offsets_dmodel = tl.arange(0, HEAD_DIM)
-    offsets_k = cur_seq_idx * stride_kt + cur_kv_head_idx * stride_kh + offsets_dmodel * stride_kd
-    offsets_v = cur_seq_idx * stride_vt + cur_kv_head_idx * stride_vh + offsets_dmodel * stride_vd
 
-    k = tl.load(K + offsets_k)
-    v = tl.load(V + offsets_v)
+    range_x = tl.arange(0, KCACHE_X)
+    offsets_dmodel_x_partition = tl.arange(0, KCACHE_X)
 
-    offsets_kcache = (
-        block_id * stride_cachekb
-        + cur_kv_head_idx * stride_cachekh
-        + offsets_in_last_block * stride_cachekbs
-        + offsets_dmodel * stride_cachekd
-    )
-    offsets_vcache = (
-        block_id * stride_cachevb
-        + cur_kv_head_idx * stride_cachevh
-        + offsets_in_last_block * stride_cachevbs
-        + offsets_dmodel * stride_cachevd
-    )
+    for split_x in tl.static_range(HEAD_DIM // KCACHE_X):
+        offsets_dmodel_x_partition = tl.arange(split_x * KCACHE_X, (split_x + 1) * KCACHE_X)
+        offsets_k = cur_seq_idx * stride_kt + cur_kv_head_idx * stride_kh + offsets_dmodel_x_partition * stride_kd
+        k = tl.load(K + offsets_k)
+        offsets_v = cur_seq_idx * stride_vt + cur_kv_head_idx * stride_vh + offsets_dmodel_x_partition * stride_vd
+        v = tl.load(V + offsets_v)
 
-    tl.store(KCache + offsets_kcache, k)
-    tl.store(VCache + offsets_vcache, v)
+        offsets_kcache = (
+            block_id * stride_kcb
+            + cur_kv_head_idx * stride_kch
+            + split_x * stride_kcsplit_x
+            + offsets_in_last_block * stride_kcs
+            + range_x
+        )
+        tl.store(KCache + offsets_kcache, k)
+        offsets_vcache = (
+            block_id * stride_vcb
+            + cur_kv_head_idx * stride_vch
+            + offsets_in_last_block * stride_vcs
+            + offsets_dmodel_x_partition * stride_vcd
+        )
+        tl.store(VCache + offsets_vcache, v)
     return
 
 
 def copy_k_to_blocked_cache(
-    k: torch.Tensor, k_cache: torch.Tensor, kv_lengths: torch.Tensor, block_tables: torch.Tensor, n: int = 1
+    k: torch.Tensor,
+    k_cache: torch.Tensor,
+    kv_lengths: torch.Tensor,
+    block_tables: torch.Tensor,
+    n: int = 1,
+    use_new_kcache_layout: bool = False,
 ):
     """
     Copy keys or values to the blocked key/value cache during decoding stage.
@@ -118,16 +186,27 @@ def copy_k_to_blocked_cache(
         k (torch.Tensor): [bsz, 1, num_kv_heads, head_dim]/[bsz, num_kv_heads, head_dim] - Keys or values during decoding with seq len 1.
             [bsz * n, num_kv_heads, head_dim] - Keys or values with seq len n
         k_cache (torch.Tensor): [num_blocks, num_kv_heads, block_size, head_dim] - Blocked key or value cache.
+            new KCache Layout [num_blocks, num_kv_heads, head_dim // x, block_size, x]
         kv_lengths (torch.Tensor): [bsz] - Past key/value sequence lengths plus current sequence length for each sequence.
         block_tables (torch.Tensor): [bsz, max_blocks_per_sequence] - Block tables for each sequence.
         n (int): Number of tokens to copy for each sequence. Default to 1.
+        use_new_kcache_layout (bool): Whether to use the new layout for kcache. Default to False.
     """
-    assert k.size(-1) == k_cache.size(-1), "Incompatible head dim"
     assert k.dtype == k_cache.dtype, "Expected consistent dtype for tensor and cache."
+    if k.dim() == 4:
+        k = k.reshape(-1, k.size(-2), k.size(-1))
+    k_shape = k.shape
+    k_cache_shape = k_cache.shape
+    if use_new_kcache_layout:
+        assert (
+            len(k_cache_shape) == 5
+            and k_cache_shape[1] == k_shape[1]
+            and k_cache_shape[2] * k_cache_shape[4] == k_shape[2]
+        ), f"Incompatible k_cache shape {k_cache_shape} with k shape {k_shape}"
+    else:
+        assert k_cache_shape[-1] == k_shape[-1], f"Incompatible head dim"
 
-    k = k.reshape(-1, k.size(-2), k.size(-1)) if k.dim() == 4 else k
-    assert k.dim() == 3, f"Invalid k dim {k.dim()}"
-    bsz, num_kv_heads, head_dim = k.shape
+    bsz, num_kv_heads, head_dim = k_shape
     # NOTE when n > 1, the shape of k is [bsz * n, num_kv_heads, head_dim]
     if n > 1:
         assert bsz % n == 0, "Each sequence should have the same number of tokens to be copied"
@@ -140,12 +219,23 @@ def copy_k_to_blocked_cache(
     )
 
     # Modify if the shape of kv cahce is changed.
-    block_size = k_cache.size(-2)
+    block_size = k_cache_shape[-2]
 
     num_warps = 8 if head_dim > 128 else 4
 
-    grid = (bsz * n, num_kv_heads)
-    _copy_to_kcache_seqlen_n_kernel[grid](
+    x = head_dim
+    stride_kcsplit_x = 0
+    stride_kcs = k_cache.stride(2)
+    stride_kcd = k_cache.stride(3)
+    if use_new_kcache_layout:
+        # Intuition: x: 16 // dtype_size
+        # when using kcache layout [num_blocks, num_kv_heads, head_dim // x, block_size, x]
+        x = k_cache.size(-1)
+        stride_kcsplit_x, stride_kcs, stride_kcd = k_cache.stride()[2:]
+
+    grid = (bsz * n, num_kv_heads, head_dim // x)
+
+    _copy_to_kcache_seqlen_n_kernel_v2[grid](
         k,
         k_cache,
         block_tables,
@@ -155,13 +245,15 @@ def copy_k_to_blocked_cache(
         k.stride(2),
         k_cache.stride(0),
         k_cache.stride(1),
-        k_cache.stride(2),
-        k_cache.stride(3),
+        stride_kcsplit_x,
+        stride_kcs,
+        stride_kcd,
         block_tables.stride(0),
         block_tables.stride(1),
         block_size,
-        n=n,
+        n_tokens=n,
         HEAD_DIM=head_dim,
+        KCACHE_X=x,
         num_warps=num_warps,
     )
 
@@ -173,6 +265,7 @@ def copy_kv_to_blocked_cache(
     v_cache: torch.Tensor,
     kv_lengths: torch.Tensor,
     block_tables: torch.Tensor,
+    use_new_kcache_layout: bool = False,
 ):
     """
     Copy keys or values to the blocked key/value cache during decoding stage.
@@ -184,19 +277,30 @@ def copy_kv_to_blocked_cache(
         v_cache (torch.Tensor): [num_blocks, num_kv_heads, block_size, head_dim] - Blocked value cache.
         kv_lengths (torch.Tensor): [bsz] - Past key/value sequence lengths plus current sequence length for each sequence.
         block_tables (torch.Tensor): [bsz, max_blocks_per_sequence] - Block tables for each sequence.
+        use_new_kcache_layout (bool): Whether to use the new layout for kcache. Default to False.
     """
-    assert k.size(-1) == k_cache.size(-1), "Incompatible head dim"
-    assert k.dtype == k_cache.dtype, "Expected consistent dtype for tensor and cache."
+    k_cache_shape = k_cache.shape
+    v_cache_shape = v_cache.shape
+
+    if use_new_kcache_layout:
+        assert (
+            len(k_cache_shape) == 5
+            and k_cache_shape[1] == v_cache_shape[1]
+            and k_cache_shape[2] * k_cache_shape[4] == v_cache_shape[3]
+        ), f"Invalid KCache shape {k_cache_shape} and VCache shape {v_cache_shape}"
+    else:
+        assert k.size(-1) == k_cache_shape[-1], "Incompatible head dim"
+        assert (
+            k_cache_shape == v_cache_shape
+        ), f"Incompatible KCache shape {k_cache_shape} and VCache shape {v_cache_shape}"
+    assert v.size(-1) == v_cache_shape[-1], "Incompatible head dim"
+
     k = k.squeeze(1) if k.dim() == 4 else k
     assert k.dim() == 3, f"Incompatible k dim {k.dim()}"
-
-    assert v.size(-1) == v_cache.size(-1), "Incompatible head dim"
-    assert v.dtype == v_cache.dtype, "Expected consistent dtype for tensor and cache."
     v = v.squeeze(1) if v.dim() == 4 else v
     assert v.dim() == 3, f"Incompatible v dim {v.dim()}"
 
     bsz, num_kv_heads, head_dim = k.shape
-
     assert kv_lengths.shape[0] == block_tables.shape[0] == bsz, (
         f"Got incompatible batch size (number of seqs):\n"
         f"  Past kv sequence lengths bsz {kv_lengths.shape[0]}; "
@@ -205,6 +309,15 @@ def copy_kv_to_blocked_cache(
 
     # Modify if the shape of kv cahce is changed.
     block_size = k_cache.size(-2)
+    x = head_dim
+    stride_kcsplit_x = 0
+    stride_kcs = k_cache.stride(2)
+    stride_kcd = k_cache.stride(3)
+    if k_cache.dim() == 5:
+        # Intuition: x: 16 // dtype_size
+        # when using kcache layout [num_blocks, num_kv_heads, head_dim // x, block_size, x]
+        x = k_cache.size(-1)
+        stride_kcsplit_x, stride_kcs, stride_kcd = k_cache.stride()[2:]
 
     num_warps = 8 if head_dim > 128 else 4
     grid = (bsz, num_kv_heads)
@@ -223,8 +336,9 @@ def copy_kv_to_blocked_cache(
         v.stride(2),
         k_cache.stride(0),
         k_cache.stride(1),
-        k_cache.stride(2),
-        k_cache.stride(3),
+        stride_kcsplit_x,
+        stride_kcs,
+        stride_kcd,
         v_cache.stride(0),
         v_cache.stride(1),
         v_cache.stride(2),
@@ -233,5 +347,6 @@ def copy_kv_to_blocked_cache(
         block_tables.stride(1),
         block_size,
         HEAD_DIM=head_dim,
+        KCACHE_X=x,
         num_warps=num_warps,
     )

--- a/examples/inference/benchmark_ops/benchmark_fused_rotary_embdding_unpad.py
+++ b/examples/inference/benchmark_ops/benchmark_fused_rotary_embdding_unpad.py
@@ -7,6 +7,11 @@ from tests.test_infer.test_ops.triton.kernel_utils import (
     mock_alloc_block_table_and_kvcache_v3,
     mock_alloc_single_token,
 )
+from tests.test_infer.test_ops.triton.kernel_utils import (
+    mock_alloc_block_table_and_kvcache_v2,
+    mock_alloc_block_table_and_kvcache_v3,
+    mock_alloc_single_token,
+)
 
 inference_ops = InferenceOpsLoader().load()
 
@@ -24,18 +29,20 @@ configs = [
         x_vals=[2**i for i in range(4, 11)],
         line_arg="provider",
         line_vals=[
-            "no_fused_triton_rotary_emb_func",
-            "fused_triton_rotary_emb_func",
-            "no_fused_cuda_rotary_emb_func",
-            "fused_cuda_rotary_emb_func",
+            "triton_rotary_emb_func",
+            "triton_fused_rotary_emb_func",
+            "triton_fused_rotary_emb_func_new_kcache_layout",
+            "cuda_rotary_emb_func",
+            "cuda_fused_rotary_emb_func",
         ],
         line_names=[
-            "no_fused_triton_rotary_emb_func",
-            "fused_triton_rotary_emb_func",
-            "no_fused_cuda_rotary_emb_func",
-            "fused_cuda_rotary_emb_func",
+            "triton_rotary_emb_func",
+            "triton_fused_rotary_emb_func",
+            "triton_fused_rotary_emb_func(new layout)",
+            "cuda_rotary_emb_func",
+            "cuda_fused_rotary_emb_func",
         ],
-        styles=[("red", "-"), ("blue", "-"), ("green", "-"), ("yellow", "-")],
+        styles=[("red", "-"), ("blue", "-"), ("purple", "-"), ("green", "-"), ("yellow", "-")],
         ylabel="ms",
         plot_name=f"rotary_emb-batch-{BATCH}",
         args={"num_kv_heads": 16},
@@ -91,31 +98,44 @@ def benchmark_rotary_emb(
     kv_seq_lengths = past_kv_seq_lengths + 1
     block_tables = block_tables.to(device="cuda")
 
-    if provider == "no_fused_triton_rotary_emb_func":
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == "triton_rotary_emb_func":
         fn = lambda: [
             rotary_embedding(new_q, new_k, cos, sin),
             copy_kv_to_blocked_cache(
                 new_k, new_v, k_cache, v_cache, kv_lengths=kv_seq_lengths, block_tables=block_tables
             ),
         ]
-    elif provider == "fused_triton_rotary_emb_func":
+    elif provider == "triton_fused_rotary_emb_func":
         fn = lambda: decoding_fused_rotary_embedding(
             new_q, new_k, new_v, cos, sin, k_cache, v_cache, block_tables, kv_seq_lengths
         )
-    elif provider == "no_fused_cuda_rotary_emb_func":
+    elif provider == "triton_fused_rotary_emb_func_new_kcache_layout":
+        x = 16 // torch.tensor([], dtype=dtype).element_size()
+        kcache_shape = (BATCH_SIZE * max_num_blocks_per_seq, num_kv_heads, head_dim // x, block_size, x)
+        k_cache = torch.zeros(size=kcache_shape, dtype=dtype, device="cuda")
+        block_tables = mock_alloc_block_table_and_kvcache_v3(
+            k, v, k_cache, v_cache, past_kv_seq_lengths, BATCH_SIZE, max_num_blocks_per_seq, block_size
+        )
+        mock_alloc_single_token(block_tables, past_kv_seq_lengths, block_size)
+        block_tables = block_tables.to(device="cuda")
+        fn = lambda: decoding_fused_rotary_embedding(
+            new_q, new_k, new_v, cos, sin, k_cache, v_cache, block_tables, kv_seq_lengths, use_new_kcache_layout=True
+        )
+    elif provider == "cuda_rotary_emb_func":
         fn = lambda: [
             inference_ops.rotary_embedding(new_q, new_k, cos, sin, True),
             inference_ops.decode_kv_cache_memcpy(new_k, new_v, new_k_cache, v_cache, kv_seq_lengths, block_tables),
         ]
-    elif provider == "fused_cuda_rotary_emb_func":
+    elif provider == "cuda_fused_rotary_emb_func":
         fn = lambda: inference_ops.rotary_embedding_and_cache_copy(
             new_q, new_k, new_v, cos, sin, new_k_cache, v_cache, kv_seq_lengths, block_tables, True
         )
     else:
         raise ValueError("Undefined provider")
 
-    ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
-    return ms
+    ms, min_ms, max_ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep, quantiles=quantiles)
+    return ms, min_ms, max_ms
 
 
 if __name__ == "__main__":

--- a/examples/inference/benchmark_ops/benchmark_fused_rotary_embdding_unpad.py
+++ b/examples/inference/benchmark_ops/benchmark_fused_rotary_embdding_unpad.py
@@ -7,11 +7,6 @@ from tests.test_infer.test_ops.triton.kernel_utils import (
     mock_alloc_block_table_and_kvcache_v3,
     mock_alloc_single_token,
 )
-from tests.test_infer.test_ops.triton.kernel_utils import (
-    mock_alloc_block_table_and_kvcache_v2,
-    mock_alloc_block_table_and_kvcache_v3,
-    mock_alloc_single_token,
-)
 
 inference_ops = InferenceOpsLoader().load()
 

--- a/tests/test_infer/test_ops/triton/test_decoding_attn.py
+++ b/tests/test_infer/test_ops/triton/test_decoding_attn.py
@@ -93,7 +93,7 @@ def test_flash_decoding(
         # the code (alibi kernel) will be refactored later to avoid code duplication, when
         # the whole triton flow with new k cache layout has been supported and tested.
         # And tests for the alibi kernel using new kcache layout will be added then.
-        return
+        pytest.skip("Alibi kernel does not support new kcache layout yet.")
 
     torch.manual_seed(123)
     torch.cuda.empty_cache()

--- a/tests/test_infer/test_ops/triton/test_decoding_attn.py
+++ b/tests/test_infer/test_ops/triton/test_decoding_attn.py
@@ -10,6 +10,7 @@ from tests.test_infer.test_ops.triton.kernel_utils import (
     convert_kv_unpad_to_padded,
     create_attention_mask,
     generate_caches_and_block_tables_v2,
+    generate_caches_and_block_tables_v3,
     torch_attn_ref,
 )
 from tests.test_infer.test_ops.triton.test_context_attn_unpad import generate_alibi_mask
@@ -75,6 +76,7 @@ def prepare_data(
 @pytest.mark.parametrize("same_context_len", [True, False])
 @pytest.mark.parametrize("q_len", [1, 5])
 @pytest.mark.parametrize("use_alibi_slopes", [True, False])
+@pytest.mark.parametrize("use_new_kcache_layout", [True, False])
 def test_flash_decoding(
     bsz: int,
     block_size: int,
@@ -84,7 +86,15 @@ def test_flash_decoding(
     same_context_len: bool,
     q_len: int,
     use_alibi_slopes: bool,
+    use_new_kcache_layout: bool,
 ):
+    if use_new_kcache_layout and use_alibi_slopes:
+        # TODO(yuanheng-zhao): Since the alibi kernel is pretty similar to the original one,
+        # the code (alibi kernel) will be refactored later to avoid code duplication, when
+        # the whole triton flow with new k cache layout has been supported and tested.
+        # And tests for the alibi kernel using new kcache layout will be added then.
+        return
+
     torch.manual_seed(123)
     torch.cuda.empty_cache()
     torch.cuda.synchronize()
@@ -127,9 +137,14 @@ def test_flash_decoding(
         q, k_torch, v_torch, attention_mask, bsz, q_len, max_kv_len_in_b, num_attn_heads, num_kv_heads, HEAD_DIM
     )
 
-    k_cache, v_cache, block_tables = generate_caches_and_block_tables_v2(
-        k_unpad, v_unpad, kv_lengths, bsz, max_num_blocks_per_seq, block_size, dtype, device
-    )
+    if use_new_kcache_layout:
+        k_cache, v_cache, block_tables = generate_caches_and_block_tables_v3(
+            k_unpad, v_unpad, kv_lengths, bsz, max_num_blocks_per_seq, block_size, dtype, device
+        )
+    else:
+        k_cache, v_cache, block_tables = generate_caches_and_block_tables_v2(
+            k_unpad, v_unpad, kv_lengths, bsz, max_num_blocks_per_seq, block_size, dtype, device
+        )
     block_tables = block_tables.to(device=device)
     # The maximum block length splitted on kv should be the kv cache block size
     kv_max_split_num = (max_kv_len_in_b + block_size - 1) // block_size
@@ -165,6 +180,7 @@ def test_flash_decoding(
         sm_scale=sm_scale,
         kv_group_num=kv_group_num,
         q_len=q_len,
+        use_new_kcache_layout=use_new_kcache_layout,
     )  # [bsz * q_len, num_heads, head_dim]
 
     assert out_torch.shape == out_triton.shape
@@ -178,4 +194,4 @@ def test_flash_decoding(
 
 
 if __name__ == "__main__":
-    test_flash_decoding(16, 32, 32, 16, 1, True, 1, True)
+    test_flash_decoding(16, 32, 32, 16, 1, True, 1, use_alibi_slopes=False, use_new_kcache_layout=True)

--- a/tests/test_infer/test_ops/triton/test_kvcache_copy.py
+++ b/tests/test_infer/test_ops/triton/test_kvcache_copy.py
@@ -4,7 +4,11 @@ from packaging import version
 
 from colossalai.kernel.triton import copy_k_to_blocked_cache, copy_kv_to_blocked_cache
 from colossalai.utils import get_current_device
-from tests.test_infer.test_ops.triton.kernel_utils import generate_caches_and_block_tables_v2, mock_alloc_single_token
+from tests.test_infer.test_ops.triton.kernel_utils import (
+    generate_caches_and_block_tables_v2,
+    generate_caches_and_block_tables_v3,
+    mock_alloc_single_token,
+)
 
 try:
     import triton  # noqa
@@ -30,6 +34,7 @@ def prepare_data(
     n=1,
     device="cuda",
     dtype=torch.float16,
+    use_new_kcache_layout=False,
 ):
     assert max_seq_len > n, "max_seq_len must be greater than n"
 
@@ -44,9 +49,14 @@ def prepare_data(
     kv_unpad = torch.empty(size=kv_size, dtype=dtype, device=device).normal_(mean=0.0, std=0.5)
     k_unpad, v_unpad = torch.split(kv_unpad, [num_kv_heads, num_kv_heads], dim=-2)
 
-    k_cache, v_cache, block_tables = generate_caches_and_block_tables_v2(
-        k_unpad, v_unpad, past_kv_seq_lengths, bsz, max_num_blocks_per_seq, block_size, dtype=dtype, device=device
-    )
+    if use_new_kcache_layout:
+        k_cache, v_cache, block_tables = generate_caches_and_block_tables_v3(
+            k_unpad, v_unpad, past_kv_seq_lengths, bsz, max_num_blocks_per_seq, block_size, dtype=dtype, device=device
+        )
+    else:
+        k_cache, v_cache, block_tables = generate_caches_and_block_tables_v2(
+            k_unpad, v_unpad, past_kv_seq_lengths, bsz, max_num_blocks_per_seq, block_size, dtype=dtype, device=device
+        )
     block_tables = block_tables.to(device=device)
 
     new_k = torch.randn((bsz, n, num_kv_heads, head_dim), dtype=dtype, device=device)
@@ -66,8 +76,15 @@ def prepare_data(
 @pytest.mark.parametrize("num_kv_heads", [16])
 @pytest.mark.parametrize("same_context_len", [True, False])
 @pytest.mark.parametrize("n_tokens", [1, 5])
+@pytest.mark.parametrize("use_new_kcache_layout", [True, False])
 def test_copy_kv_to_caches(
-    bsz: int, block_size: int, max_num_blocks_per_seq: int, num_kv_heads: int, same_context_len: bool, n_tokens: int
+    bsz: int,
+    block_size: int,
+    max_num_blocks_per_seq: int,
+    num_kv_heads: int,
+    same_context_len: bool,
+    n_tokens: int,
+    use_new_kcache_layout: bool,
 ):
     torch.manual_seed(123)
     torch.cuda.empty_cache()
@@ -89,6 +106,7 @@ def test_copy_kv_to_caches(
         n_tokens,
         device=device,
         dtype=dtype,
+        use_new_kcache_layout=use_new_kcache_layout,
     )
     k_source = new_k.view(-1, new_k.size(-2), new_k.size(-1))
     v_source = new_v.view(-1, new_v.size(-2), new_v.size(-1))
@@ -98,7 +116,9 @@ def test_copy_kv_to_caches(
     offsets_in_block = past_kv_seq_lengths % block_size
 
     # Copy k (or v) to k (or v) cache
-    copy_k_to_blocked_cache(new_k, k_cache, kv_seq_lengths, block_tables, n=n_tokens)
+    copy_k_to_blocked_cache(
+        new_k, k_cache, kv_seq_lengths, block_tables, n=n_tokens, use_new_kcache_layout=use_new_kcache_layout
+    )
     # Reshape target k from k cache to compare if matching with original tensor
     # Mainly to handle cases of n_tokens > 1
     k_target = []
@@ -110,26 +130,39 @@ def test_copy_kv_to_caches(
         while tokens_left > 0:
             tokens_to_fill = min(block_size - offset, tokens_left)
             curr_block_id = block_table[curr_kv_len // block_size]
-            k_target.append(k_cache[curr_block_id, :, offset : offset + tokens_to_fill, :])
+            if use_new_kcache_layout:
+                k_target.append(k_cache[curr_block_id, :, :, offset : offset + tokens_to_fill, :])
+            else:
+                k_target.append(k_cache[curr_block_id, :, offset : offset + tokens_to_fill, :])
             curr_kv_len += tokens_to_fill
             tokens_left -= tokens_to_fill
             offset = 0
-    k_target = torch.concat(k_target, dim=1).transpose(0, 1).contiguous()  # [bsz * n, num_kv_heads, head_dim]
-
+    if use_new_kcache_layout:
+        k_target = torch.concat(k_target, dim=2).permute(2, 0, 1, 3).contiguous()
+        k_target = k_target.reshape(bsz * n_tokens, num_kv_heads, HEAD_DIM)
+    else:
+        k_target = torch.concat(k_target, dim=1).transpose(0, 1).contiguous()  # [bsz * n, num_kv_heads, head_dim]
     assert k_target.shape == k_source.shape
     assert torch.equal(k_target, k_source)
 
     if n_tokens == 1:
         # Copy k and v to k/v caches
         k_cache = k_cache_copy
-        copy_kv_to_blocked_cache(new_k, new_v, k_cache, v_cache, kv_seq_lengths, block_tables)
-        k_target = k_cache_copy[target_block_ids, :, offsets_in_block, :]
-        v_target = v_cache[target_block_ids, :, offsets_in_block, :]
+        copy_kv_to_blocked_cache(
+            new_k, new_v, k_cache, v_cache, kv_seq_lengths, block_tables, use_new_kcache_layout=use_new_kcache_layout
+        )
+
+        if use_new_kcache_layout:
+            k_target = k_cache[target_block_ids, :, :, offsets_in_block, :]
+            k_target = k_target.contiguous().reshape(bsz * n_tokens, num_kv_heads, HEAD_DIM)
+        else:
+            k_target = k_cache[target_block_ids, :, offsets_in_block, :]
         assert k_target.shape == k_source.shape
         assert torch.equal(k_target, k_source)
+        v_target = v_cache[target_block_ids, :, offsets_in_block, :]
         assert v_target.shape == v_source.shape
         assert torch.equal(v_target, v_source)
 
 
 if __name__ == "__main__":
-    test_copy_kv_to_caches(4, 32, 8, 16, True)
+    test_copy_kv_to_caches(4, 32, 8, 16, True, n_tokens=1)


### PR DESCRIPTION
## 📌 Checklist before creating the PR

- [ ] I have created an issue for this PR for traceability
- [x] The title follows the standard format: `[doc/gemini/tensor/...]: A concise description`
- [ ] I have added relevant tags if possible for us to better distinguish different PRs
- [x] I have installed pre-commit: `pip install pre-commit && pre-commit install`


## 🚨 Issue number

> Link this PR to your issue with words like fixed to automatically close the linked issue upon merge
>
> e.g. `fixed #1234`, `closed #1234`, `resolved #1234`



## 📝 What does this PR do?

> Summarize your work here.
> if you have any plots/diagrams/screenshots/tables, please attach them here.

Add support for new kcache layout(`[num_blocks, num_kv_heads, head_dim // x, block_size, x]`) in relevant triton kernels. Note that this PR only modifies triton kernels in use.

TODO: clean kernel files, remove unused triton kernels.

KV_SEQ_LEN | torch_copy_func | triton_copy_func | triton_new_kcache_layout | cuda_copy_func
-- | -- | -- | -- | --
256.0 | 0.869984 | 0.005952 | 0.008800 | 0.006720
512.0 | 0.866688 | 0.006208 | 0.009088 | 0.006720
1024.0 | 0.872000 | 0.005984 | 0.008832 | 0.006464
2048.0 | 0.868960 | 0.006208 | 0.008832 | 0.006496
4096.0 | 0.868192 | 0.006208 | 0.008800 | 0.006464


KV_LEN | Torch | Triton | Triton New KCache Layout
-- | -- | -- | --
256.0 | 0.123808 | 0.038016 | 0.038304
512.0 | 0.219824 | 0.044960 | 0.060512
1024.0 | 0.423088 | 0.072704 | 0.106208
2048.0 | 0.819856 | 0.128256 | 0.196800
4096.0 | 1.658496 | 0.238880 | 0.376864
8192.0 | 3.216544 | 0.460800 | 0.737984


num_tokens | triton_rotary_emb_func | triton_fused_rotary_emb_func | triton_fused_rotary_emb_func(new layout) | cuda_rotary_emb_func | cuda_fused_rotary_emb_func
-- | -- | -- | -- | -- | --
16.0 | 0.018560 | 0.010688 | 0.031584 | 0.044032 | 0.035872
32.0 | 0.016000 | 0.010688 | 0.031344 | 0.043904 | 0.035872
64.0 | 0.015808 | 0.010592 | 0.031264 | 0.043936 | 0.036032
128.0 | 0.016032 | 0.010688 | 0.031392 | 0.043840 | 0.035904
256.0 | 0.015968 | 0.010624 | 0.031296 | 0.044224 | 0.036032
512.0 | 0.015552 | 0.010592 | 0.031360 | 0.043776 | 0.035968
1024.0 | 0.015328 | 0.010624 | 0.031584 | 0.043968 | 0.035776


<img width="1392" alt="image" src="https://github.com/hpcaitech/ColossalAI/assets/54058983/b5893867-0dff-40ca-a880-e6edcbb67979">


## 💥 Checklist before requesting a review

- [ ] I have linked my PR to an issue ([instruction](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
- [x] My issue clearly describes the problem/feature/proposal, with diagrams/charts/table/code if possible
- [x] I have performed a self-review of my code
- [x] I have added thorough tests.
- [x] I have added docstrings for all the functions/methods I implemented

## ⭐️ Do you enjoy contributing to Colossal-AI?

- [x] 🌝 Yes, I do.
- [ ] 🌚 No, I don't.

Tell us more if you don't enjoy contributing to Colossal-AI.
