### PR TITLE
[Shardformer]fix the num_heads assert for llama model and qwen model

### DIFF
--- a/colossalai/shardformer/modeling/qwen2.py
+++ b/colossalai/shardformer/modeling/qwen2.py
@@ -24,10 +24,6 @@ except ImportError:
     Qwen2ForCausalLM = "Qwen2ForCausalLM"
     Qwen2Attention = "Qwen2Attention"
     Qwen2ForSequenceClassification = "Qwen2ForSequenceClassification"
-    repeat_kv = "repeat_kv"
-    apply_rotary_pos_emb = "apply_rotary_pos_emb"
-    _prepare_4d_causal_attention_mask = "_prepare_4d_causal_attention_mask"
-    _prepare_4d_causal_attention_mask_for_sdpa = "_prepare_4d_causal_attention_mask_for_sdpa"
 
 from transformers.utils import logging
 

--- a/colossalai/shardformer/modeling/qwen2.py
+++ b/colossalai/shardformer/modeling/qwen2.py
@@ -14,19 +14,21 @@ try:
         Qwen2Attention,
         Qwen2ForCausalLM,
         Qwen2ForSequenceClassification,
+        repeat_kv,
+        apply_rotary_pos_emb,
+        _prepare_4d_causal_attention_mask,
+        _prepare_4d_causal_attention_mask_for_sdpa
     )
 except ImportError:
     Qwen2Model = "Qwen2Model"
     Qwen2ForCausalLM = "Qwen2ForCausalLM"
     Qwen2Attention = "Qwen2Attention"
     Qwen2ForSequenceClassification = "Qwen2ForSequenceClassification"
+    repeat_kv = "repeat_kv"
+    apply_rotary_pos_emb = "apply_rotary_pos_emb"
+    _prepare_4d_causal_attention_mask = "_prepare_4d_causal_attention_mask"
+    _prepare_4d_causal_attention_mask_for_sdpa = "_prepare_4d_causal_attention_mask_for_sdpa"
 
-from transformers.models.qwen2.modeling_qwen2 import (
-    repeat_kv,
-    apply_rotary_pos_emb,
-    _prepare_4d_causal_attention_mask,
-    _prepare_4d_causal_attention_mask_for_sdpa
-)
 from transformers.utils import logging
 
 from colossalai.pipeline.stage_manager import PipelineStageManager

--- a/colossalai/shardformer/modeling/qwen2.py
+++ b/colossalai/shardformer/modeling/qwen2.py
@@ -10,17 +10,23 @@ from transformers.modeling_outputs import (
 
 try:
     from transformers.models.qwen2.modeling_qwen2 import (
+        Qwen2Model,
+        Qwen2Attention,
         Qwen2ForCausalLM,
         Qwen2ForSequenceClassification,
-        Qwen2Model,
-        _prepare_4d_causal_attention_mask,
-        _prepare_4d_causal_attention_mask_for_sdpa,
     )
 except ImportError:
     Qwen2Model = "Qwen2Model"
-    Qwen2ForSequenceClassification = "Qwen2ForSequenceClassification"
     Qwen2ForCausalLM = "Qwen2ForCausalLM"
+    Qwen2Attention = "Qwen2Attention"
+    Qwen2ForSequenceClassification = "Qwen2ForSequenceClassification"
 
+from transformers.models.qwen2.modeling_qwen2 import (
+    repeat_kv,
+    apply_rotary_pos_emb,
+    _prepare_4d_causal_attention_mask,
+    _prepare_4d_causal_attention_mask_for_sdpa
+)
 from transformers.utils import logging
 
 from colossalai.pipeline.stage_manager import PipelineStageManager
@@ -450,10 +456,7 @@ class Qwen2PipelineForwards:
             return {"hidden_states": hidden_states}
 
 
-def get_qwen2_flash_attention_forward(shard_config: ShardConfig):
-    from transformers.models.qwen2.modeling_qwen2 import Qwen2Attention, apply_rotary_pos_emb, repeat_kv
-
-    from colossalai.shardformer.layer import ColoAttention
+def get_qwen2_flash_attention_forward(shard_config: ShardConfig):\
 
     def forward(
         self: Qwen2Attention,

--- a/colossalai/shardformer/policies/llama.py
+++ b/colossalai/shardformer/policies/llama.py
@@ -141,9 +141,11 @@ class LlamaPolicy(Policy):
             assert (
                 self.model.config.num_attention_heads % self.shard_config.tensor_parallel_size == 0
             ), f"The number of attention heads must be divisible by tensor parallel size."
-            assert (
-                self.model.config.num_key_value_heads % self.shard_config.tensor_parallel_size == 0
-            ), f"The number of key_value heads must be divisible by tensor parallel size."
+            if hasattr(self.model.config, "num_key_value_heads"):
+                assert (
+                    self.model.config.num_key_value_heads >= self.shard_config.tensor_parallel_size
+                    and self.model.config.num_key_value_heads % self.shard_config.tensor_parallel_size == 0
+                ), f"The number of key_value heads must be divisible by, and must not be less than tensor parallel size."
             decoder_attribute_replacement = {
                 "self_attn.hidden_size": self.model.config.hidden_size // self.shard_config.tensor_parallel_size,
                 "self_attn.num_heads": self.model.config.num_attention_heads // self.shard_config.tensor_parallel_size,

--- a/colossalai/shardformer/policies/qwen2.py
+++ b/colossalai/shardformer/policies/qwen2.py
@@ -21,10 +21,28 @@ from ..modeling.qwen2 import (
     get_qwen2_flash_attention_forward,
     get_qwen2_model_forward_for_flash_attn,
 )
+try:
+    from transformers.models.qwen2.modeling_qwen2 import (
+        Qwen2ForCausalLM,
+        Qwen2ForSequenceClassification,
+        Qwen2Attention,
+        Qwen2DecoderLayer,
+        Qwen2FlashAttention2,
+        Qwen2Model,
+        Qwen2SdpaAttention,
+    )
+except ImportError:
+    Qwen2ForCausalLM = "Qwen2ForCausalLM"
+    Qwen2ForSequenceClassification = "Qwen2ForSequenceClassification"
+    Qwen2Attention = "Qwen2Attention"
+    Qwen2FlashAttention2 = "Qwen2FlashAttention2"
+    Qwen2SdpaAttention = "Qwen2SdpaAttention"
+    Qwen2DecoderLayer = "Qwen2DecoderLayer"
+    Qwen2Model = "Qwen2Model"
+
 from .base_policy import ModulePolicyDescription, Policy, SubModuleReplacementDescription
 
 __all__ = ["Qwen2Policy", "Qwen2ForCausalLMPolicy", "Qwen2ForSequenceClassificationPolicy"]
-
 
 class Qwen2Policy(Policy):
     def __init__(self) -> None:
@@ -45,20 +63,6 @@ class Qwen2Policy(Policy):
         return self.model
 
     def module_policy(self) -> Dict[Union[str, nn.Module], ModulePolicyDescription]:
-        try:
-            from transformers.models.qwen2.modeling_qwen2 import (
-                Qwen2Attention,
-                Qwen2DecoderLayer,
-                Qwen2FlashAttention2,
-                Qwen2Model,
-                Qwen2SdpaAttention,
-            )
-        except ImportError:
-            Qwen2Attention = "Qwen2Attention"
-            Qwen2FlashAttention2 = "Qwen2FlashAttention2"
-            Qwen2SdpaAttention = "Qwen2SdpaAttention"
-            Qwen2DecoderLayer = "Qwen2DecoderLayer"
-            Qwen2Model = "Qwen2Model"
 
         ATTN_IMPLEMENTATION = {
             "eager": Qwen2Attention,
@@ -82,6 +86,13 @@ class Qwen2Policy(Policy):
             warnings.warn("Qwen2 doesn't support sequence parallelism now, will ignore the sequence parallelism flag.")
 
         if self.shard_config.enable_tensor_parallelism:
+            assert (
+                self.model.config.num_attention_heads % self.shard_config.tensor_parallel_size == 0
+            ), f"The number of attention heads must be divisible by tensor parallel size."
+            if hasattr(self.model.config, "num_key_value_heads"):
+                assert (
+                self.model.config.num_key_value_heads % self.shard_config.tensor_parallel_size == 0
+            ), f"The number of key_value heads must be divisible by tensor parallel size."
             decoder_attribute_replacement = {
                 "self_attn.hidden_size": self.model.config.hidden_size // self.shard_config.tensor_parallel_size,
                 "self_attn.num_heads": self.model.config.num_attention_heads // self.shard_config.tensor_parallel_size,
@@ -256,7 +267,6 @@ class Qwen2Policy(Policy):
 class Qwen2ModelPolicy(Qwen2Policy):
     def module_policy(self):
         policy = super().module_policy()
-        from transformers.models.qwen2.modeling_qwen2 import Qwen2Model
 
         if self.pipeline_stage_manager:
             # set None as default
@@ -277,10 +287,7 @@ class Qwen2ModelPolicy(Qwen2Policy):
 
 class Qwen2ForCausalLMPolicy(Qwen2Policy):
     def module_policy(self):
-        from transformers import Qwen2ForCausalLM
-
         policy = super().module_policy()
-
         setattr(self.shard_config, "causal_lm", True)
 
         if self.shard_config.enable_tensor_parallelism:
@@ -330,10 +337,7 @@ class Qwen2ForCausalLMPolicy(Qwen2Policy):
 
 class Qwen2ForSequenceClassificationPolicy(Qwen2Policy):
     def module_policy(self):
-        from transformers import Qwen2ForSequenceClassification
-
         policy = super().module_policy()
-
         if self.shard_config.enable_tensor_parallelism:
             # add a new item for sequence classification
             new_item = {


### PR DESCRIPTION
Fix the num_heads assert for llama model and qwen model, and fix the transformers import in qwen model.
Already tested the test_shard_qwen2.py locally.
![img_v3_02ao_6270eddb-b4c5-480f-b5a2-72a01626217g](https://github.com/hpcaitech/ColossalAI/assets/32676639/d472c272-a29d-4142-afc2-0f45a92ef587)
