### PR TITLE
[Feature] Add a switch to control whether the model checkpoint needs to be saved after each epoch ends

### DIFF
--- a/applications/Colossal-LLaMA/train.py
+++ b/applications/Colossal-LLaMA/train.py
@@ -128,6 +128,11 @@ def main() -> None:
     parser.add_argument("--zero", type=int, default=1)
     parser.add_argument("--pad_token", choices=["eos", "unk"], default="eos")
     parser.add_argument("--padding_mode", choices=["max_length", "longest"], default="max_length")
+    parser.add_argument(
+        "--skip_save_each_epoch",
+        action="store_true",
+        default=False,
+        help="skip saving the model checkpoint after each epoch is completed.")
     args = parser.parse_args()
 
     with open(args.config_file, "w") as f:
@@ -370,11 +375,15 @@ def main() -> None:
                     )
                 total_loss.fill_(0.0)
                 pbar.update()
+                
             # Save modeling.
 
-            if (args.save_interval > 0 and (step + 1) % (args.save_interval * args.accumulation_steps) == 0) or (
-                step + 1
-            ) == len(dataloader):
+            save_model_condition = (args.save_interval > 0 and (step + 1) % (args.save_interval * args.accumulation_steps) == 0)
+
+            if not args.skip_save_each_epoch:
+                save_model_condition = save_model_condition or (step + 1) == len(dataloader)
+
+            if save_model_condition:
                 coordinator.print_on_master("\nStart saving model checkpoint with running states")
 
                 if args.use_neft:

--- a/applications/Colossal-LLaMA/train.py
+++ b/applications/Colossal-LLaMA/train.py
@@ -132,7 +132,8 @@ def main() -> None:
         "--skip_save_each_epoch",
         action="store_true",
         default=False,
-        help="skip saving the model checkpoint after each epoch is completed.")
+        help="skip saving the model checkpoint after each epoch is completed.",
+    )
     args = parser.parse_args()
 
     with open(args.config_file, "w") as f:
@@ -375,10 +376,12 @@ def main() -> None:
                     )
                 total_loss.fill_(0.0)
                 pbar.update()
-                
+
             # Save modeling.
 
-            save_model_condition = (args.save_interval > 0 and (step + 1) % (args.save_interval * args.accumulation_steps) == 0)
+            save_model_condition = (
+                args.save_interval > 0 and (step + 1) % (args.save_interval * args.accumulation_steps) == 0
+            )
 
             if not args.skip_save_each_epoch:
                 save_model_condition = save_model_condition or (step + 1) == len(dataloader)


### PR DESCRIPTION
## 📌 Checklist before creating the PR

- [x] I have created an issue for this PR for traceability
- [x] The title follows the standard format: `[doc/gemini/tensor/...]: A concise description`
- [x] I have added relevant tags if possible for us to better distinguish different PRs
- [x] I have installed pre-commit: `pip install pre-commit && pre-commit install`


## 🚨 Issue number

> resolved #5937



## 📝 What does this PR do?

For debugging scenarios, saving model files for each epoch would consume a lot of time and disk space, so I think it is necessary to add a parameter for users to choose whether to do so

Now you can use `--skip_save_each_epoch` to skip saving the model checkpoint of each epoch,  just like this:

![image](https://github.com/user-attachments/assets/902f00f9-1b19-4f94-924e-2d4bf2b53be3)

: )



## 💥 Checklist before requesting a review

- [x] I have linked my PR to an issue ([instruction](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
- [x] My issue clearly describes the problem/feature/proposal, with diagrams/charts/table/code if possible
- [x] I have performed a self-review of my code
- [x] I have added thorough tests.
- [x] I have added docstrings for all the functions/methods I implemented

## ⭐️ Do you enjoy contributing to Colossal-AI?

- [x] 🌝 Yes, I do.
- [ ] 🌚 No, I don't.

Tell us more if you don't enjoy contributing to Colossal-AI.
