### PR TITLE
[Fix] fix the 2d ring attn when using multiple machine

### DIFF
--- a/colossalai/shardformer/layer/attn.py
+++ b/colossalai/shardformer/layer/attn.py
@@ -4,7 +4,6 @@ from typing import Callable, Dict, Optional, Tuple
 import torch
 import torch.distributed
 import torch.distributed as dist
-from torch.distributed import ProcessGroup
 import torch.nn.functional as F
 from einops import rearrange
 
@@ -432,7 +431,7 @@ class RingAttention(torch.autograd.Function):
     INTER_RING_GROUP_COPY: dist.ProcessGroup = None
 
     @staticmethod
-    def get_double_ring_groups(sp_group,tp_group, inner_ring_size=None):
+    def get_double_ring_groups(sp_group, tp_group, inner_ring_size=None):
         """
         Get 2D ring groups for the given process group. Generally, to avoid congestion, the inner ring size
         shouldn't be larger than the number of NICs on each node.
@@ -443,8 +442,8 @@ class RingAttention(torch.autograd.Function):
             Tuple[dist.ProcessGroup, dist.ProcessGroup]: Inner-ring process group and inter-ring process group.
         """
         sp_size = dist.get_world_size(sp_group)
-        sp_rank = dist.get_rank(sp_group)
-        tp_size = dist.get_world_size(tp_group)
+        dist.get_rank(sp_group)
+        dist.get_world_size(tp_group)
 
         if inner_ring_size is None:
             if torch.cuda.device_count() >= dist.get_world_size():
@@ -475,11 +474,11 @@ class RingAttention(torch.autograd.Function):
 
         world_size = dist.get_world_size()
         rank = dist.get_rank()
-        groups = int(world_size/ sp_size)
+        groups = int(world_size / sp_size)
         # Create inner ring groups
         for group_id in range(groups):
             for i in range(inner_ring_size):
-                ranks = list(range(i +(group_id*sp_size), (1+group_id)*sp_size, inner_ring_size))
+                ranks = list(range(i + (group_id * sp_size), (1 + group_id) * sp_size, inner_ring_size))
                 group = dist.new_group(ranks)
                 if rank in ranks:
                     inner_ring_group = group
@@ -487,7 +486,7 @@ class RingAttention(torch.autograd.Function):
         # Create inter ring groups
         for group_id in range(groups):
             for i in range(num_rings):
-                ranks = list(range(i+group_id * num_rings, world_size, sp_size))
+                ranks = list(range(i + group_id * num_rings, world_size, sp_size))
                 group = dist.new_group(ranks)
                 if rank in ranks:
                     inter_ring_group = group
@@ -557,7 +556,9 @@ class RingAttention(torch.autograd.Function):
 
         if RingAttention.SP_GROUP is not sp_group:
             RingAttention.SP_GROUP = sp_group
-            inner_ring_group, inter_ring_group = RingAttention.get_double_ring_groups(sp_group, tp_group, inner_ring_size)
+            inner_ring_group, inter_ring_group = RingAttention.get_double_ring_groups(
+                sp_group, tp_group, inner_ring_size
+            )
             RingAttention.INNER_RING_GROUP = inner_ring_group
             RingAttention.INTER_RING_GROUP = inter_ring_group
         else:

--- a/colossalai/shardformer/modeling/llama.py
+++ b/colossalai/shardformer/modeling/llama.py
@@ -563,12 +563,14 @@ def get_llama_flash_attention_forward(shard_config: ShardConfig, sp_mode=None, s
         key_states = repeat_kv(key_states, self.num_key_value_groups)
         value_states = repeat_kv(value_states, self.num_key_value_groups)
 
+        tp_group = shard_config.tensor_parallel_process_group
         if sp_mode == "ring_attn":
             attn_output = RingAttention.attention(
                 query_states,
                 key_states,
                 value_states,
                 sp_group,
+                tp_group,
                 **attention_mask,
                 inner_ring_size=shard_config.inner_ring_size,
             )


### PR DESCRIPTION
## 🚨 Issue number

fixed #6017



## 📝 What does this PR do?

The double_ring_groups need to consider the tp groups as the tp axis is the first axis.
And the ranks in double_ring_groups need to transformered into global ranks.

For example, if using the first four cards of two machines, totaling eight cards for ring attention, the ranks of the inner ring group would be [0, 2], [1, 3], [4, 6], [5, 7], while the ranks of the inter ring group would be [0, 4], [1, 5], [2, 6], [3, 7].

Results:
![image](https://github.com/user-attachments/assets/189628f6-0509-4356-a7e5-e56ab11103d3)



