### PR TITLE
fix: resolve multi-node training hanging in Kubernetes environments

### DIFF
--- a/colossalai/utils/__init__.py
+++ b/colossalai/utils/__init__.py
@@ -16,15 +16,16 @@ from .timer import MultiTimer, Timer
 # Kubernetes distributed training utilities
 try:
     from .k8s_distributed import (
-        validate_k8s_environment,
-        setup_k8s_networking,
-        diagnose_distributed_issues,
-        generate_torchrun_command,
         create_k8s_headless_service_yaml,
         create_k8s_job_yaml,
+        diagnose_distributed_issues,
+        generate_torchrun_command,
+        setup_k8s_networking,
+        validate_k8s_environment,
     )
+
     _k8s_utils_available = True
-    
+
     __all__ = [
         "conditional_context",
         "Timer",
@@ -41,7 +42,7 @@ try:
         "get_non_persistent_buffers_set",
         # K8s distributed training utilities
         "validate_k8s_environment",
-        "setup_k8s_networking", 
+        "setup_k8s_networking",
         "diagnose_distributed_issues",
         "generate_torchrun_command",
         "create_k8s_headless_service_yaml",
@@ -49,7 +50,7 @@ try:
     ]
 except ImportError:
     _k8s_utils_available = False
-    
+
     __all__ = [
         "conditional_context",
         "Timer",

--- a/colossalai/utils/k8s_distributed.py
+++ b/colossalai/utils/k8s_distributed.py
@@ -10,25 +10,26 @@ network discovery, and rendezvous configuration.
 """
 
 import os
-import time
 import socket
 import subprocess
-from typing import Dict, List, Optional, Tuple
+import time
+from typing import Dict, List
+
 from colossalai.logging import get_dist_logger
 
 
 def validate_k8s_environment() -> Dict[str, str]:
     """
     Validate and return Kubernetes environment variables for distributed training.
-    
+
     Returns:
         Dict[str, str]: Dictionary of validated environment variables
-        
+
     Raises:
         RuntimeError: If required environment variables are missing or invalid
     """
     logger = get_dist_logger()
-    
+
     # Essential environment variables for K8s distributed training
     essential_vars = {
         "MASTER_ADDR": "Master node service DNS name or IP",
@@ -36,45 +37,47 @@ def validate_k8s_environment() -> Dict[str, str]:
         "WORLD_SIZE": "Total number of processes",
         "RANK": "Global rank of current process",
         "LOCAL_RANK": "Local rank on current node",
-        "NODE_RANK": "Rank of current node"
+        "NODE_RANK": "Rank of current node",
     }
-    
+
     # Optional but recommended variables
     recommended_vars = {
         "RDZV_ID": "Unique job identifier for rendezvous",
         "NCCL_SOCKET_IFNAME": "Network interface for NCCL (e.g., eth0)",
         "GLOO_SOCKET_IFNAME": "Network interface for Gloo backend",
         "NCCL_DEBUG": "NCCL debug level (INFO for debugging)",
-        "NCCL_IB_DISABLE": "Disable InfiniBand (set to 1 in most K8s envs)"
+        "NCCL_IB_DISABLE": "Disable InfiniBand (set to 1 in most K8s envs)",
     }
-    
+
     env_vars = {}
     missing_vars = []
-    
+
     # Check essential variables
     for var, description in essential_vars.items():
         if var in os.environ:
             env_vars[var] = os.environ[var]
         else:
             missing_vars.append(f"  - {var}: {description}")
-    
+
     if missing_vars:
-        error_msg = ("Missing essential environment variables for K8s distributed training:\n" +
-                    "\n".join(missing_vars) +
-                    "\n\nExample Kubernetes deployment configuration:\n"
-                    "env:\n"
-                    "  - name: MASTER_ADDR\n"
-                    "    value: \"training-master-service.default.svc.cluster.local\"\n"
-                    "  - name: MASTER_PORT\n"
-                    "    value: \"29500\"\n"
-                    "  - name: WORLD_SIZE\n"
-                    "    value: \"32\"  # 4 nodes * 8 GPUs\n"
-                    "  - name: NODE_RANK\n"
-                    "    valueFrom:\n"
-                    "      fieldRef:\n"
-                    "        fieldPath: metadata.annotations['batch.kubernetes.io/job-completion-index']\n")
+        error_msg = (
+            "Missing essential environment variables for K8s distributed training:\n"
+            + "\n".join(missing_vars)
+            + "\n\nExample Kubernetes deployment configuration:\n"
+            "env:\n"
+            "  - name: MASTER_ADDR\n"
+            '    value: "training-master-service.default.svc.cluster.local"\n'
+            "  - name: MASTER_PORT\n"
+            '    value: "29500"\n'
+            "  - name: WORLD_SIZE\n"
+            '    value: "32"  # 4 nodes * 8 GPUs\n'
+            "  - name: NODE_RANK\n"
+            "    valueFrom:\n"
+            "      fieldRef:\n"
+            "        fieldPath: metadata.annotations['batch.kubernetes.io/job-completion-index']\n"
+        )
         raise RuntimeError(error_msg)
-    
+
     # Log recommended variables
     for var, description in recommended_vars.items():
         if var in os.environ:
@@ -82,26 +85,26 @@ def validate_k8s_environment() -> Dict[str, str]:
             logger.info(f"Using {var}={os.environ[var]}")
         else:
             logger.warning(f"Recommended environment variable {var} not set: {description}")
-    
+
     return env_vars
 
 
 def wait_for_pods_ready(world_size: int, timeout: int = 600) -> bool:
     """
     Wait for all pods in the distributed training job to be ready.
-    
+
     Args:
         world_size (int): Expected number of processes
         timeout (int): Maximum time to wait in seconds
-        
+
     Returns:
         bool: True if all pods are ready, False otherwise
     """
     logger = get_dist_logger()
     start_time = time.time()
-    
+
     logger.info(f"Waiting for {world_size} processes to be ready...")
-    
+
     while time.time() - start_time < timeout:
         try:
             # In K8s, we can check if the expected number of pods are running
@@ -112,7 +115,7 @@ def wait_for_pods_ready(world_size: int, timeout: int = 600) -> bool:
         except Exception as e:
             logger.debug(f"Pod readiness check failed: {e}")
             time.sleep(10)
-    
+
     logger.error(f"Not all pods became ready within {timeout} seconds")
     return False
 
@@ -122,15 +125,15 @@ def setup_k8s_networking():
     Configure networking settings optimized for Kubernetes environments.
     """
     logger = get_dist_logger()
-    
+
     # Set networking environment variables if not already set
     network_config = {
         "NCCL_IB_DISABLE": "1",  # Disable InfiniBand in most K8s environments
         "NCCL_SOCKET_IFNAME": "eth0",  # Default K8s network interface
         "GLOO_SOCKET_IFNAME": "eth0",
-        "NCCL_DEBUG": os.environ.get("NCCL_DEBUG", "WARN")  # Don't override if already set
+        "NCCL_DEBUG": os.environ.get("NCCL_DEBUG", "WARN"),  # Don't override if already set
     }
-    
+
     for var, value in network_config.items():
         if var not in os.environ:
             os.environ[var] = value
@@ -147,11 +150,11 @@ def generate_torchrun_command(
     node_rank: int = None,
     master_addr: str = None,
     master_port: int = None,
-    rdzv_id: str = None
+    rdzv_id: str = None,
 ) -> str:
     """
     Generate an enhanced torchrun command for Kubernetes multi-node training.
-    
+
     Args:
         script_path (str): Path to the training script
         script_args (List[str], optional): Arguments for the training script
@@ -161,7 +164,7 @@ def generate_torchrun_command(
         master_addr (str, optional): Master address (read from env if not provided)
         master_port (int, optional): Master port (read from env if not provided)
         rdzv_id (str, optional): Rendezvous ID (generated if not provided)
-        
+
     Returns:
         str: Complete torchrun command
     """
@@ -172,7 +175,7 @@ def generate_torchrun_command(
     master_addr = master_addr or os.environ.get("MASTER_ADDR", "localhost")
     master_port = master_port or int(os.environ.get("MASTER_PORT", "29500"))
     rdzv_id = rdzv_id or os.environ.get("RDZV_ID", f"colossalai_job_{int(time.time())}")
-    
+
     # Build torchrun command with enhanced configuration
     cmd_parts = [
         "torchrun",
@@ -185,12 +188,12 @@ def generate_torchrun_command(
         "--rdzv_conf=timeout=1800,read_timeout=120",  # 30min timeout, 2min read timeout
         f"--master_addr={master_addr}",
         f"--master_port={master_port}",
-        script_path
+        script_path,
     ]
-    
+
     if script_args:
         cmd_parts.extend(script_args)
-    
+
     return " \\\n  ".join(cmd_parts)
 
 
@@ -198,17 +201,17 @@ def create_k8s_headless_service_yaml(
     service_name: str = "colossalai-training-service",
     namespace: str = "default",
     port: int = 29500,
-    app_label: str = "colossalai-training"
+    app_label: str = "colossalai-training",
 ) -> str:
     """
     Generate YAML configuration for a Kubernetes headless service for distributed training.
-    
+
     Args:
         service_name (str): Name of the service
         namespace (str): Kubernetes namespace
         port (int): Service port
         app_label (str): App label selector
-        
+
     Returns:
         str: YAML configuration
     """
@@ -231,7 +234,7 @@ spec:
     targetPort: {port}
     protocol: TCP
 ---
-# Optional: Service for master node specifically  
+# Optional: Service for master node specifically
 apiVersion: v1
 kind: Service
 metadata:
@@ -260,11 +263,11 @@ def create_k8s_job_yaml(
     image: str = "your-training-image:latest",
     num_nodes: int = 4,
     gpus_per_node: int = 8,
-    script_command: List[str] = None
+    script_command: List[str] = None,
 ) -> str:
     """
     Generate YAML configuration for a Kubernetes Job for multi-node training.
-    
+
     Args:
         job_name (str): Name of the training job
         namespace (str): Kubernetes namespace
@@ -272,13 +275,13 @@ def create_k8s_job_yaml(
         num_nodes (int): Number of nodes
         gpus_per_node (int): GPUs per node
         script_command (List[str]): Command to run training script
-        
+
     Returns:
         str: YAML configuration
     """
     if script_command is None:
         script_command = ["python", "scripts/diffusion/train.py", "configs/diffusion/train/demo.py"]
-    
+
     yaml_config = f"""# ColossalAI Multi-Node Training Job
 apiVersion: batch/v1
 kind: Job
@@ -304,7 +307,7 @@ spec:
         - |
           # Wait a bit for all pods to start
           sleep $((RANDOM % 30 + 30))
-          
+
           # Enhanced torchrun command
           torchrun \\
             --nnodes={num_nodes} \\
@@ -364,7 +367,7 @@ spec:
 def diagnose_distributed_issues() -> Dict[str, any]:
     """
     Diagnose common distributed training issues in Kubernetes environments.
-    
+
     Returns:
         Dict[str, any]: Diagnosis results and recommendations
     """
@@ -374,20 +377,20 @@ def diagnose_distributed_issues() -> Dict[str, any]:
         "dns_resolution": False,
         "port_availability": False,
         "environment_variables": False,
-        "recommendations": []
+        "recommendations": [],
     }
-    
+
     # Check environment variables
     required_envs = ["MASTER_ADDR", "MASTER_PORT", "WORLD_SIZE", "RANK", "LOCAL_RANK"]
     missing_envs = [env for env in required_envs if env not in os.environ]
-    
+
     if not missing_envs:
         diagnosis["environment_variables"] = True
         logger.info("✓ All required environment variables are set")
     else:
         logger.error(f"✗ Missing environment variables: {missing_envs}")
         diagnosis["recommendations"].append(f"Set missing environment variables: {missing_envs}")
-    
+
     # Check DNS resolution
     if "MASTER_ADDR" in os.environ:
         try:
@@ -398,7 +401,7 @@ def diagnose_distributed_issues() -> Dict[str, any]:
         except socket.gaierror:
             logger.error(f"✗ DNS resolution failed for {master_addr}")
             diagnosis["recommendations"].append("Check if master service DNS name is correct and accessible")
-    
+
     # Check port connectivity
     if "MASTER_ADDR" in os.environ and "MASTER_PORT" in os.environ:
         try:
@@ -411,12 +414,11 @@ def diagnose_distributed_issues() -> Dict[str, any]:
         except (socket.error, socket.timeout, ConnectionRefusedError):
             logger.error(f"✗ Cannot connect to {master_addr}:{master_port}")
             diagnosis["recommendations"].append("Check if master node is running and port is open")
-    
+
     # Network interface check
     nccl_interface = os.environ.get("NCCL_SOCKET_IFNAME", "eth0")
     try:
-        result = subprocess.run(["ip", "addr", "show", nccl_interface], 
-                              capture_output=True, text=True, timeout=5)
+        result = subprocess.run(["ip", "addr", "show", nccl_interface], capture_output=True, text=True, timeout=5)
         if result.returncode == 0:
             diagnosis["network_connectivity"] = True
             logger.info(f"✓ Network interface {nccl_interface} is available")
@@ -425,5 +427,5 @@ def diagnose_distributed_issues() -> Dict[str, any]:
             diagnosis["recommendations"].append(f"Check network interface configuration (current: {nccl_interface})")
     except (subprocess.SubprocessError, FileNotFoundError):
         logger.warning("Could not check network interface (ip command not available)")
-    
+
     return diagnosis

--- a/examples/k8s_2node_test/2node-test-job.yaml
+++ b/examples/k8s_2node_test/2node-test-job.yaml
@@ -40,54 +40,54 @@ spec:
         - -c
         - |
           set -e  # Exit on error
-          
+
           echo "=== Node $JOB_COMPLETION_INDEX startup ==="
           echo "Time: $(date)"
           echo "Hostname: $(hostname)"
           echo "Pod IP: $(hostname -i)"
-          
+
           # Install ColossalAI if not in image (remove if already installed)
           # pip install colossalai
-          
+
           # Stagger startup to reduce race conditions
           sleep_time=$((JOB_COMPLETION_INDEX * 30 + 30))
           echo "Sleeping for ${sleep_time}s to stagger startup..."
           sleep $sleep_time
-          
+
           # Set rank calculations
           export RANK=$((JOB_COMPLETION_INDEX * 8))
           export LOCAL_RANK=0
-          
+
           echo "=== Environment Configuration ==="
           echo "NODE_RANK: $JOB_COMPLETION_INDEX"
-          echo "RANK: $RANK" 
+          echo "RANK: $RANK"
           echo "LOCAL_RANK: $LOCAL_RANK"
           echo "WORLD_SIZE: $WORLD_SIZE"
           echo "MASTER_ADDR: $MASTER_ADDR"
           echo "MASTER_PORT: $MASTER_PORT"
-          
+
           # Test DNS resolution
           echo "=== Testing DNS Resolution ==="
           nslookup $MASTER_ADDR || echo "DNS resolution failed"
-          
+
           # Test network connectivity (only for non-master nodes)
           if [ "$JOB_COMPLETION_INDEX" != "0" ]; then
             echo "=== Testing Master Connectivity ==="
             timeout 10 bash -c "cat < /dev/null > /dev/tcp/$MASTER_ADDR/$MASTER_PORT" || echo "Master port not yet accessible"
           fi
-          
+
           echo "=== Starting Enhanced Torchrun ==="
-          
+
           # Create a simple test script if Open-Sora scripts not available
           cat > /tmp/test_distributed.py << 'EOF'
           import os
           import sys
           import torch
           import torch.distributed as dist
-          
+
           # Add the current directory to path for ColossalAI imports
           sys.path.insert(0, '/workspace')  # Adjust path as needed
-          
+
           try:
               import colossalai
               print("✓ ColossalAI imported successfully")
@@ -96,51 +96,51 @@ spec:
               print("Installing ColossalAI...")
               os.system("pip install colossalai")
               import colossalai
-          
+
           def main():
               print(f"=== Process {os.environ.get('RANK', 'unknown')} starting ===")
-              
+
               # Initialize ColossalAI with enhanced error handling
               try:
                   colossalai.launch_from_torch(verbose=True)
                   print("✓ ColossalAI initialization successful!")
-                  
+
                   # Basic distributed tests
                   rank = dist.get_rank()
                   world_size = dist.get_world_size()
-                  
+
                   print(f"Process {rank}/{world_size} initialized successfully!")
-                  
+
                   # Test basic collective operation
                   if torch.cuda.is_available():
                       device = torch.cuda.current_device()
                       tensor = torch.ones(1).cuda() * rank
                       print(f"[Rank {rank}] Before all_reduce: {tensor.item()}")
-                      
+
                       dist.all_reduce(tensor)
                       expected = sum(range(world_size))
-                      
+
                       print(f"[Rank {rank}] After all_reduce: {tensor.item()}, expected: {expected}")
-                      
+
                       if abs(tensor.item() - expected) < 1e-6:
                           print(f"✓ [Rank {rank}] All-reduce test PASSED")
                       else:
                           print(f"✗ [Rank {rank}] All-reduce test FAILED")
-                  
+
                   print(f"🎉 [Rank {rank}] All tests completed successfully!")
                   return 0
-                  
+
               except Exception as e:
                   print(f"✗ ColossalAI initialization failed: {e}")
                   import traceback
                   traceback.print_exc()
                   return 1
-          
+
           if __name__ == "__main__":
               exit_code = main()
               sys.exit(exit_code)
           EOF
-          
+
           # Run the enhanced torchrun command
           torchrun \
             --nnodes=2 \
@@ -153,11 +153,11 @@ spec:
             --master_addr=$MASTER_ADDR \
             --master_port=$MASTER_PORT \
             /tmp/test_distributed.py
-            
+
           # If you have Open-Sora installed, use this instead:
           # scripts/diffusion/train.py configs/diffusion/train/demo.py \
           # --dataset.data-path modified_data.csv
-          
+
         env:
         # Essential distributed training variables
         - name: MASTER_ADDR
@@ -170,13 +170,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['batch.kubernetes.io/job-completion-index']
-        
+
         # Enhanced ColossalAI timeout configuration
         - name: COLOSSALAI_DIST_TIMEOUT
           value: "1800"  # 30 minutes for initialization
         - name: COLOSSALAI_MASTER_READY_TIMEOUT
           value: "600"   # 10 minutes for master readiness
-        
+
         # Kubernetes networking configuration
         - name: NCCL_SOCKET_IFNAME
           value: "eth0"
@@ -186,11 +186,11 @@ spec:
           value: "1"
         - name: NCCL_DEBUG
           value: "INFO"  # Detailed logging for testing
-        
+
         # Optional: Enable distributed diagnostics
         - name: DEBUG_DISTRIBUTED
           value: "1"
-        
+
         resources:
           requests:
             nvidia.com/gpu: 8
@@ -200,13 +200,13 @@ spec:
             nvidia.com/gpu: 8
             memory: "64Gi"
             cpu: "32"
-        
+
         volumeMounts:
         - name: shm
           mountPath: /dev/shm
         - name: workspace
           mountPath: /workspace
-      
+
       volumes:
       - name: shm
         emptyDir:
@@ -214,11 +214,11 @@ spec:
           sizeLimit: 32Gi  # Large shared memory for distributed training
       - name: workspace
         emptyDir: {}  # Temporary workspace
-      
+
       # Optional: Node selection for GPU nodes
       # nodeSelector:
       #   accelerator: nvidia-tesla-v100
-      
+
       # Optional: Tolerations for GPU nodes
       # tolerations:
       # - key: nvidia.com/gpu

--- a/examples/k8s_2node_test/README.md
+++ b/examples/k8s_2node_test/README.md
@@ -46,17 +46,17 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: metadata.annotations['batch.kubernetes.io/job-completion-index']
-  
+
   # Enhanced timeout configuration
   - name: COLOSSALAI_DIST_TIMEOUT
     value: "1800"  # 30 minutes for init
   - name: COLOSSALAI_MASTER_READY_TIMEOUT
     value: "600"   # 10 minutes for master readiness
-  
+
   # K8s networking
   - name: NCCL_SOCKET_IFNAME
     value: "eth0"
-  - name: GLOO_SOCKET_IFNAME  
+  - name: GLOO_SOCKET_IFNAME
     value: "eth0"
   - name: NCCL_IB_DISABLE
     value: "1"
@@ -133,13 +133,13 @@ spec:
         - |
           # Stagger startup to avoid race conditions
           sleep $((JOB_COMPLETION_INDEX * 30 + 30))
-          
+
           # Set rank based on completion index
           export RANK=$((JOB_COMPLETION_INDEX * 8))
           export LOCAL_RANK=0
-          
+
           echo "Node $JOB_COMPLETION_INDEX starting with RANK=$RANK"
-          
+
           # Enhanced torchrun command
           torchrun \
             --nnodes=2 \
@@ -207,7 +207,7 @@ spec:
    ```bash
    # Watch logs from both pods
    kubectl logs -l job-name=opensora-2node-test -f --prefix=true
-   
+
    # Or individual pods
    kubectl logs opensora-2node-test-0-xxxxx -f
    kubectl logs opensora-2node-test-1-xxxxx -f
@@ -242,7 +242,7 @@ spec:
    - name: DEBUG_DISTRIBUTED
      value: "1"
    - name: NCCL_DEBUG
-     value: "INFO" 
+     value: "INFO"
    ```
 
 ### Common Issues:

--- a/examples/k8s_2node_test/test_deployment.sh
+++ b/examples/k8s_2node_test/test_deployment.sh
@@ -59,15 +59,15 @@ elapsed=0
 while [ $elapsed -lt $timeout ]; do
     status=$(get_pod_status)
     echo "Pod status: $status"
-    
+
     # Check if both pods are running
     running_pods=$(kubectl get pods -l job-name=opensora-multinode-test --no-headers 2>/dev/null | grep "Running" | wc -l)
-    
+
     if [ "$running_pods" -eq 2 ]; then
         echo "✓ Both pods are running!"
         break
     fi
-    
+
     sleep 10
     elapsed=$((elapsed + 10))
 done
@@ -92,10 +92,10 @@ check_logs() {
     local pod_name=$1
     echo ""
     echo "📋 Checking logs for $pod_name..."
-    
+
     # Get recent logs
     logs=$(kubectl logs $pod_name --tail=50 2>/dev/null || echo "No logs available yet")
-    
+
     # Check for success indicators
     if echo "$logs" | grep -q "ColossalAI initialization successful"; then
         echo "✓ $pod_name: ColossalAI initialization successful"
@@ -110,7 +110,7 @@ check_logs() {
     else
         echo "⏳ $pod_name: Still initializing..."
     fi
-    
+
     # Check for error indicators
     if echo "$logs" | grep -q "initialization failed"; then
         echo "✗ $pod_name: Initialization failed"
@@ -130,17 +130,17 @@ monitor_elapsed=0
 while [ $monitor_elapsed -lt $monitor_timeout ] && [ $success_count -lt 2 ]; do
     # Get current pod names
     pod_names=$(kubectl get pods -l job-name=opensora-multinode-test --no-headers -o custom-columns=":metadata.name" 2>/dev/null)
-    
+
     for pod in $pod_names; do
         check_logs $pod
     done
-    
+
     if [ $success_count -ge 2 ]; then
         echo ""
         echo "🎉 SUCCESS: Both pods completed successfully!"
         break
     fi
-    
+
     echo "Waiting... ($monitor_elapsed/${monitor_timeout}s, successes: $success_count/2)"
     sleep 30
     monitor_elapsed=$((monitor_elapsed + 30))
@@ -164,7 +164,7 @@ if [ $success_count -ge 2 ]; then
     echo "1. Scale to 4 nodes by updating YAML (nnodes=4, WORLD_SIZE=32)"
     echo "2. Deploy your actual Open-Sora training script"
     echo "3. The fix is ready for production use!"
-    
+
     result=0
 else
     echo "⚠️  TEST INCOMPLETE: $success_count/2 nodes completed successfully"
@@ -175,7 +175,7 @@ else
     echo "3. Resource constraints in the cluster"
     echo ""
     echo "Check the detailed logs below:"
-    
+
     result=1
 fi
 

--- a/examples/k8s_multinode_example.py
+++ b/examples/k8s_multinode_example.py
@@ -4,13 +4,13 @@
 """
 Example script demonstrating the enhanced multi-node training setup for Kubernetes environments.
 
-This script addresses the issue from GitHub issue #6349 where multi-node training 
+This script addresses the issue from GitHub issue #6349 where multi-node training
 gets stuck during distributed initialization in Kubernetes environments.
 
 Usage:
     # In Kubernetes with proper environment variables set:
     python k8s_multinode_example.py
-    
+
     # Or with torchrun (enhanced command):
     torchrun --nnodes=4 --nproc_per_node=8 --node_rank=$NODE_RANK \
         --rdzv_backend=c10d --rdzv_endpoint=$MASTER_ADDR:$MASTER_PORT \
@@ -23,40 +23,32 @@ import time
 from datetime import datetime
 
 import torch
-import torch.nn as nn
 import torch.distributed as dist
+import torch.nn as nn
 
 import colossalai
-from colossalai.utils import (
-    validate_k8s_environment,
-    setup_k8s_networking,
-    diagnose_distributed_issues
-)
+from colossalai.utils import diagnose_distributed_issues, setup_k8s_networking, validate_k8s_environment
 
 
 def create_simple_model():
     """Create a simple model for testing distributed training."""
-    return nn.Sequential(
-        nn.Linear(100, 50),
-        nn.ReLU(),
-        nn.Linear(50, 10)
-    )
+    return nn.Sequential(nn.Linear(100, 50), nn.ReLU(), nn.Linear(50, 10))
 
 
 def test_distributed_operations():
     """Test basic distributed operations to verify setup."""
     rank = dist.get_rank()
     world_size = dist.get_world_size()
-    
+
     print(f"[Rank {rank}] Testing distributed operations...")
-    
+
     # Test all-reduce
     tensor = torch.ones(1).cuda() * rank
     original_value = tensor.item()
-    
+
     dist.all_reduce(tensor, op=dist.ReduceOp.SUM)
     expected_sum = sum(range(world_size))
-    
+
     if tensor.item() == expected_sum:
         print(f"[Rank {rank}] ✓ All-reduce test passed: {original_value} -> {tensor.item()} (expected: {expected_sum})")
         return True
@@ -68,39 +60,39 @@ def test_distributed_operations():
 def run_training_simulation():
     """Simulate a simple training loop to verify distributed setup."""
     rank = dist.get_rank()
-    world_size = dist.get_world_size()
-    
+    dist.get_world_size()
+
     print(f"[Rank {rank}] Starting training simulation...")
-    
+
     # Create model and move to GPU
     model = create_simple_model().cuda()
     model = nn.parallel.DistributedDataParallel(model)
-    
+
     # Simple optimizer
     optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
-    
+
     # Simulate training steps
     for step in range(5):
         # Generate random batch
         batch_size = 32
         inputs = torch.randn(batch_size, 100).cuda()
         targets = torch.randint(0, 10, (batch_size,)).cuda()
-        
+
         # Forward pass
         outputs = model(inputs)
         loss = nn.CrossEntropyLoss()(outputs, targets)
-        
+
         # Backward pass
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()
-        
+
         if rank == 0:
             print(f"[Step {step + 1}] Loss: {loss.item():.4f}")
-        
+
         # Synchronize all processes
         dist.barrier()
-    
+
     print(f"[Rank {rank}] Training simulation completed successfully!")
     return True
 
@@ -110,13 +102,13 @@ def main():
     print(f"=== ColossalAI Enhanced Multi-Node Training Example ===")
     print(f"Start time: {datetime.now()}")
     print(f"Process ID: {os.getpid()}")
-    
+
     # Step 1: Validate Kubernetes environment
     print("\n1. Validating Kubernetes environment...")
     try:
         env_vars = validate_k8s_environment()
         print(f"✓ Environment validation passed! Found {len(env_vars)} variables.")
-        
+
         # Print key environment variables for debugging
         print("Key environment variables:")
         for var in ["MASTER_ADDR", "MASTER_PORT", "WORLD_SIZE", "RANK", "LOCAL_RANK", "NODE_RANK"]:
@@ -125,50 +117,50 @@ def main():
     except RuntimeError as e:
         print(f"✗ Environment validation failed: {e}")
         return 1
-    
+
     # Step 2: Setup Kubernetes networking
     print("\n2. Setting up Kubernetes networking...")
     setup_k8s_networking()
     print("✓ Networking configuration applied")
-    
+
     # Step 3: Run diagnostics if enabled
     if os.environ.get("DEBUG_DISTRIBUTED", "0") == "1":
         print("\n3. Running distributed training diagnostics...")
         diagnosis = diagnose_distributed_issues()
-        
+
         print("Diagnosis results:")
         for check, status in diagnosis.items():
             if check == "recommendations":
                 continue
             status_str = "PASS" if status else "FAIL"
             print(f"  {check}: {status_str}")
-        
+
         if diagnosis["recommendations"]:
             print("Recommendations:")
             for i, rec in enumerate(diagnosis["recommendations"], 1):
                 print(f"  {i}. {rec}")
-    
+
     # Step 4: Initialize ColossalAI with enhanced error handling
     print("\n4. Initializing ColossalAI distributed training...")
     try:
         start_time = time.time()
         colossalai.launch_from_torch(verbose=True)
         init_time = time.time() - start_time
-        
+
         rank = dist.get_rank()
         world_size = dist.get_world_size()
         local_rank = int(os.environ.get("LOCAL_RANK", "0"))
-        
+
         print(f"✓ ColossalAI initialization successful!")
         print(f"  Initialization time: {init_time:.2f} seconds")
         print(f"  Global rank: {rank}/{world_size}")
         print(f"  Local rank: {local_rank}")
         print(f"  Device: {torch.cuda.current_device()}")
-        
+
     except Exception as e:
         print(f"✗ ColossalAI initialization failed: {e}")
         return 1
-    
+
     # Step 5: Test distributed operations
     print("\n5. Testing distributed operations...")
     try:
@@ -180,7 +172,7 @@ def main():
     except Exception as e:
         print(f"✗ Distributed operations test error: {e}")
         return 1
-    
+
     # Step 6: Run a simple training simulation
     print("\n6. Running training simulation...")
     try:
@@ -192,12 +184,12 @@ def main():
     except Exception as e:
         print(f"✗ Training simulation error: {e}")
         return 1
-    
+
     # Success!
     print(f"\n=== Multi-Node Training Setup Successful! ===")
     print(f"End time: {datetime.now()}")
     print(f"Process {dist.get_rank()}/{dist.get_world_size()} completed successfully")
-    
+
     return 0
 
 
@@ -211,6 +203,7 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"\nUnexpected error: {e}")
         import traceback
+
         traceback.print_exc()
         sys.exit(1)
     finally:

--- a/examples/k8s_multinode_training_guide.md
+++ b/examples/k8s_multinode_training_guide.md
@@ -64,7 +64,7 @@ env:
         fieldPath: metadata.annotations['batch.kubernetes.io/job-completion-index']
   - name: RDZV_ID
     value: "opensora-training-job-123"
-  
+
   # Network configuration
   - name: NCCL_SOCKET_IFNAME
     value: "eth0"
@@ -74,7 +74,7 @@ env:
     value: "1"
   - name: NCCL_DEBUG
     value: "WARN"  # Use "INFO" for debugging
-    
+
   # ColossalAI timeout configuration
   - name: COLOSSALAI_DIST_TIMEOUT
     value: "1800"  # 30 minutes for initialization
@@ -135,11 +135,11 @@ spec:
         - |
           # Wait for pod startup synchronization
           sleep \$((RANDOM % 30 + 30))
-          
+
           # Set additional environment variables
           export RANK=\$((JOB_COMPLETION_INDEX * 8))
           export LOCAL_RANK=0
-          
+
           # Enhanced torchrun command
           torchrun \\
             --nnodes=4 \\
@@ -216,15 +216,15 @@ def main():
     except RuntimeError as e:
         print(f"Environment validation failed: {e}")
         return 1
-    
+
     # Setup K8s networking
     setup_k8s_networking()
-    
+
     # Run diagnostics if needed
     if os.environ.get("DEBUG_DISTRIBUTED", "0") == "1":
         diagnosis = diagnose_distributed_issues()
         print(f"Diagnosis results: {diagnosis}")
-    
+
     # Initialize ColossalAI with enhanced error handling
     try:
         colossalai.launch_from_torch(verbose=True)
@@ -232,10 +232,10 @@ def main():
     except Exception as e:
         print(f"ColossalAI initialization failed: {e}")
         return 1
-    
+
     # Your training code here
     # ...
-    
+
     return 0
 
 if __name__ == "__main__":
@@ -252,24 +252,24 @@ import json
 def main():
     print("Running Kubernetes distributed training diagnostics...")
     diagnosis = diagnose_distributed_issues()
-    
+
     print("\\n" + "="*50)
     print("DIAGNOSIS RESULTS")
     print("="*50)
-    
+
     for check, status in diagnosis.items():
         if check == "recommendations":
             continue
         status_str = "✓ PASS" if status else "✗ FAIL"
         print(f"{check:.<30} {status_str}")
-    
+
     if diagnosis["recommendations"]:
         print("\\n" + "="*50)
         print("RECOMMENDATIONS")
         print("="*50)
         for i, rec in enumerate(diagnosis["recommendations"], 1):
             print(f"{i}. {rec}")
-    
+
     print("\\n" + json.dumps(diagnosis, indent=2))
 
 if __name__ == "__main__":
@@ -339,23 +339,23 @@ import colossalai
 def test_distributed_setup():
     try:
         colossalai.launch_from_torch(verbose=True)
-        
+
         # Basic distributed test
         rank = torch.distributed.get_rank()
         world_size = torch.distributed.get_world_size()
-        
+
         print(f"Process {rank}/{world_size} initialized successfully!")
-        
+
         # Test all-reduce operation
         tensor = torch.ones(1).cuda() * rank
         torch.distributed.all_reduce(tensor)
         expected = sum(range(world_size))
-        
+
         if tensor.item() == expected:
             print(f"✓ All-reduce test passed: {tensor.item()} == {expected}")
         else:
             print(f"✗ All-reduce test failed: {tensor.item()} != {expected}")
-            
+
         return True
     except Exception as e:
         print(f"Distributed setup test failed: {e}")

--- a/tests/test_k8s_distributed.py
+++ b/tests/test_k8s_distributed.py
@@ -9,57 +9,62 @@ that addresses multi-node training hanging issues in K8s environments.
 """
 
 import os
-import time
 import socket
-import pytest
 import threading
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
-import torch
+import pytest
 import torch.distributed as dist
 
-from colossalai.initialize import launch_from_torch, _wait_for_master_ready, _get_distributed_timeout
+from colossalai.initialize import _get_distributed_timeout, _wait_for_master_ready, launch_from_torch
 from colossalai.utils.k8s_distributed import (
-    validate_k8s_environment, 
-    setup_k8s_networking,
     diagnose_distributed_issues,
-    generate_torchrun_command
+    generate_torchrun_command,
+    setup_k8s_networking,
+    validate_k8s_environment,
 )
 
 
 class TestK8sDistributedEnhancements:
     """Test class for Kubernetes distributed training enhancements."""
-    
+
     def setup_method(self):
         """Set up test environment before each test."""
         # Clean up any existing distributed state
         if dist.is_initialized():
             dist.destroy_process_group()
-        
+
         # Clear environment variables that might interfere with tests
         test_env_vars = [
-            "RANK", "LOCAL_RANK", "WORLD_SIZE", "MASTER_ADDR", "MASTER_PORT",
-            "NCCL_DEBUG", "GLOO_SOCKET_IFNAME", "NCCL_SOCKET_IFNAME",
-            "COLOSSALAI_DIST_TIMEOUT", "COLOSSALAI_MASTER_READY_TIMEOUT"
+            "RANK",
+            "LOCAL_RANK",
+            "WORLD_SIZE",
+            "MASTER_ADDR",
+            "MASTER_PORT",
+            "NCCL_DEBUG",
+            "GLOO_SOCKET_IFNAME",
+            "NCCL_SOCKET_IFNAME",
+            "COLOSSALAI_DIST_TIMEOUT",
+            "COLOSSALAI_MASTER_READY_TIMEOUT",
         ]
         for var in test_env_vars:
             if var in os.environ:
                 del os.environ[var]
-    
+
     def teardown_method(self):
         """Clean up after each test."""
         if dist.is_initialized():
             dist.destroy_process_group()
-    
+
     def test_wait_for_master_ready_success(self):
         """Test successful master readiness check."""
         # Create a mock server that accepts connections
         server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        server_socket.bind(('localhost', 0))
+        server_socket.bind(("localhost", 0))
         port = server_socket.getsockname()[1]
         server_socket.listen(1)
-        
+
         def server_thread():
             try:
                 conn, addr = server_socket.accept()
@@ -68,43 +73,43 @@ class TestK8sDistributedEnhancements:
                 pass
             finally:
                 server_socket.close()
-        
+
         # Start server in background
         thread = threading.Thread(target=server_thread)
         thread.daemon = True
         thread.start()
-        
+
         # Test connection readiness
-        result = _wait_for_master_ready('localhost', port, timeout=10, retry_interval=1)
+        result = _wait_for_master_ready("localhost", port, timeout=10, retry_interval=1)
         assert result is True
-        
+
         thread.join(timeout=1)
-    
+
     def test_wait_for_master_ready_timeout(self):
         """Test master readiness check timeout."""
         # Use a port that won't accept connections
-        result = _wait_for_master_ready('localhost', 65432, timeout=2, retry_interval=1)
+        result = _wait_for_master_ready("localhost", 65432, timeout=2, retry_interval=1)
         assert result is False
-    
+
     def test_get_distributed_timeout_default(self):
         """Test default timeout configuration."""
         timeout = _get_distributed_timeout()
         assert timeout.seconds == 1800  # 30 minutes default
-    
+
     def test_get_distributed_timeout_custom(self):
         """Test custom timeout configuration."""
         os.environ["COLOSSALAI_DIST_TIMEOUT"] = "3600"
         timeout = _get_distributed_timeout()
         assert timeout.seconds == 3600  # 1 hour
-    
+
     def test_validate_k8s_environment_missing_vars(self):
         """Test environment validation with missing variables."""
         with pytest.raises(RuntimeError) as exc_info:
             validate_k8s_environment()
-        
+
         assert "Missing essential environment variables" in str(exc_info.value)
         assert "MASTER_ADDR" in str(exc_info.value)
-    
+
     def test_validate_k8s_environment_complete(self):
         """Test environment validation with all required variables."""
         # Set required environment variables
@@ -114,45 +119,47 @@ class TestK8sDistributedEnhancements:
             "WORLD_SIZE": "8",
             "RANK": "0",
             "LOCAL_RANK": "0",
-            "NODE_RANK": "0"
+            "NODE_RANK": "0",
         }
-        
+
         for key, value in test_env.items():
             os.environ[key] = value
-        
+
         env_vars = validate_k8s_environment()
-        
+
         # Check that all variables are returned
         for key in test_env:
             assert key in env_vars
             assert env_vars[key] == test_env[key]
-    
+
     def test_setup_k8s_networking(self):
         """Test K8s networking setup."""
         setup_k8s_networking()
-        
+
         # Check that networking environment variables are set
         assert os.environ.get("NCCL_IB_DISABLE") == "1"
         assert os.environ.get("NCCL_SOCKET_IFNAME") == "eth0"
         assert os.environ.get("GLOO_SOCKET_IFNAME") == "eth0"
         assert "NCCL_DEBUG" in os.environ
-    
+
     def test_generate_torchrun_command(self):
         """Test torchrun command generation."""
         # Set environment variables
-        os.environ.update({
-            "NNODES": "4",
-            "NPROC_PER_NODE": "8", 
-            "NODE_RANK": "0",
-            "MASTER_ADDR": "master.example.com",
-            "MASTER_PORT": "29500"
-        })
-        
+        os.environ.update(
+            {
+                "NNODES": "4",
+                "NPROC_PER_NODE": "8",
+                "NODE_RANK": "0",
+                "MASTER_ADDR": "master.example.com",
+                "MASTER_PORT": "29500",
+            }
+        )
+
         script_path = "train.py"
         script_args = ["--config", "config.yaml"]
-        
+
         command = generate_torchrun_command(script_path, script_args)
-        
+
         # Check that command contains expected elements
         assert "torchrun" in command
         assert "--nnodes=4" in command
@@ -162,60 +169,55 @@ class TestK8sDistributedEnhancements:
         assert "train.py" in command
         assert "--config" in command
         assert "config.yaml" in command
-    
+
     def test_launch_from_torch_missing_env_vars(self):
         """Test launch_from_torch with missing environment variables."""
         with pytest.raises(RuntimeError) as exc_info:
             launch_from_torch()
-        
+
         assert "Missing required environment variables" in str(exc_info.value)
         assert "torchrun" in str(exc_info.value)  # Should mention enhanced torchrun command
-    
+
     def test_launch_from_torch_invalid_values(self):
         """Test launch_from_torch with invalid environment variable values."""
         # Set environment variables with invalid values
-        os.environ.update({
-            "RANK": "not_a_number",
-            "LOCAL_RANK": "0",
-            "WORLD_SIZE": "4",
-            "MASTER_ADDR": "localhost",
-            "MASTER_PORT": "29500"
-        })
-        
+        os.environ.update(
+            {
+                "RANK": "not_a_number",
+                "LOCAL_RANK": "0",
+                "WORLD_SIZE": "4",
+                "MASTER_ADDR": "localhost",
+                "MASTER_PORT": "29500",
+            }
+        )
+
         with pytest.raises(RuntimeError) as exc_info:
             launch_from_torch()
-        
+
         assert "Invalid environment variable value" in str(exc_info.value)
-    
+
     def test_launch_from_torch_validation_checks(self):
         """Test launch_from_torch parameter validation."""
         # Test RANK >= WORLD_SIZE
-        os.environ.update({
-            "RANK": "4",
-            "LOCAL_RANK": "0", 
-            "WORLD_SIZE": "4",
-            "MASTER_ADDR": "localhost",
-            "MASTER_PORT": "29500"
-        })
-        
+        os.environ.update(
+            {"RANK": "4", "LOCAL_RANK": "0", "WORLD_SIZE": "4", "MASTER_ADDR": "localhost", "MASTER_PORT": "29500"}
+        )
+
         with pytest.raises(RuntimeError) as exc_info:
             launch_from_torch()
-        
+
         assert "RANK (4) must be less than WORLD_SIZE (4)" in str(exc_info.value)
-        
+
         # Test invalid port
-        os.environ.update({
-            "RANK": "0",
-            "MASTER_PORT": "99999"  # Invalid port
-        })
-        
+        os.environ.update({"RANK": "0", "MASTER_PORT": "99999"})  # Invalid port
+
         with pytest.raises(RuntimeError) as exc_info:
             launch_from_torch()
-        
+
         assert "MASTER_PORT (99999) must be between 1024 and 65535" in str(exc_info.value)
-    
-    @patch('torch.distributed.init_process_group')
-    @patch('colossalai.accelerator.get_accelerator')
+
+    @patch("torch.distributed.init_process_group")
+    @patch("colossalai.accelerator.get_accelerator")
     def test_launch_from_torch_success(self, mock_accelerator, mock_init_pg):
         """Test successful launch_from_torch execution."""
         # Mock accelerator
@@ -223,47 +225,39 @@ class TestK8sDistributedEnhancements:
         mock_acc.communication_backend = "nccl"
         mock_acc.support_set_device = True
         mock_accelerator.return_value = mock_acc
-        
+
         # Set valid environment variables
-        os.environ.update({
-            "RANK": "0",
-            "LOCAL_RANK": "0",
-            "WORLD_SIZE": "2", 
-            "MASTER_ADDR": "localhost",
-            "MASTER_PORT": "29500"
-        })
-        
+        os.environ.update(
+            {"RANK": "0", "LOCAL_RANK": "0", "WORLD_SIZE": "2", "MASTER_ADDR": "localhost", "MASTER_PORT": "29500"}
+        )
+
         # Mock successful process group initialization
         mock_init_pg.return_value = None
-        
+
         # Should not raise any exceptions
         launch_from_torch(verbose=False)
-        
+
         # Verify that init_process_group was called with timeout
         mock_init_pg.assert_called_once()
         call_args = mock_init_pg.call_args
-        assert 'timeout' in call_args.kwargs
-    
+        assert "timeout" in call_args.kwargs
+
     def test_diagnose_distributed_issues(self):
         """Test distributed training diagnostics."""
         # Set some environment variables for testing
-        os.environ.update({
-            "MASTER_ADDR": "localhost",
-            "MASTER_PORT": "29500",
-            "WORLD_SIZE": "2",
-            "RANK": "0",
-            "LOCAL_RANK": "0"
-        })
-        
+        os.environ.update(
+            {"MASTER_ADDR": "localhost", "MASTER_PORT": "29500", "WORLD_SIZE": "2", "RANK": "0", "LOCAL_RANK": "0"}
+        )
+
         diagnosis = diagnose_distributed_issues()
-        
+
         # Check that diagnosis returns expected structure
         assert "network_connectivity" in diagnosis
-        assert "dns_resolution" in diagnosis  
+        assert "dns_resolution" in diagnosis
         assert "port_availability" in diagnosis
         assert "environment_variables" in diagnosis
         assert "recommendations" in diagnosis
-        
+
         # Environment variables should pass
         assert diagnosis["environment_variables"] is True
         assert isinstance(diagnosis["recommendations"], list)
@@ -271,38 +265,35 @@ class TestK8sDistributedEnhancements:
 
 class TestK8sYamlGeneration:
     """Test YAML generation functions."""
-    
+
     def test_create_k8s_headless_service_yaml(self):
         """Test headless service YAML generation."""
         from colossalai.utils.k8s_distributed import create_k8s_headless_service_yaml
-        
+
         yaml_content = create_k8s_headless_service_yaml(
-            service_name="test-service",
-            namespace="test-ns",
-            port=12345,
-            app_label="test-app"
+            service_name="test-service", namespace="test-ns", port=12345, app_label="test-app"
         )
-        
+
         # Check that YAML contains expected content
         assert "name: test-service" in yaml_content
         assert "namespace: test-ns" in yaml_content
         assert "port: 12345" in yaml_content
         assert "app: test-app" in yaml_content
         assert "clusterIP: None" in yaml_content
-    
+
     def test_create_k8s_job_yaml(self):
         """Test training job YAML generation."""
         from colossalai.utils.k8s_distributed import create_k8s_job_yaml
-        
+
         yaml_content = create_k8s_job_yaml(
             job_name="test-job",
             namespace="test-ns",
             image="test:latest",
             num_nodes=2,
             gpus_per_node=4,
-            script_command=["python", "test.py"]
+            script_command=["python", "test.py"],
         )
-        
+
         # Check that YAML contains expected content
         assert "name: test-job" in yaml_content
         assert "namespace: test-ns" in yaml_content
@@ -316,12 +307,11 @@ class TestK8sYamlGeneration:
 @pytest.mark.skip(reason="Requires actual distributed environment")
 class TestDistributedIntegration:
     """Integration tests that require actual distributed setup."""
-    
+
     def test_full_distributed_initialization(self):
         """Test complete distributed initialization flow."""
         # This would require actual multi-process setup
         # Skip for now but can be used for manual testing
-        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

  Addresses issue #6349 where multi-node training gets stuck during distributed initialization when using torchrun in Kubernetes.

  ## Root Cause
  - Missing rendezvous backend configuration in torchrun
  - No master node readiness checks in K8s pod startup
  - Insufficient timeout configuration for container networking
  - Lack of Kubernetes-specific networking setup

  ## Solution

  ### Enhanced Initialization (colossalai/initialize.py)
  - Add master node readiness checks for non-master ranks
  - Implement configurable timeouts via environment variables
  - Provide detailed error messages with troubleshooting guidance
  - Add robust error handling for distributed process group init

  ### Kubernetes Utilities (colossalai/utils/k8s_distributed.py)
  - Environment variable validation with helpful errors
  - Automatic K8s networking configuration (NCCL, Gloo)
  - YAML generation for headless services and training jobs
  - Comprehensive diagnostics and troubleshooting tools

  ### Documentation & Examples
  - Complete K8s multi-node training guide
  - Minimal 2-node test setup for validation
  - Working example with distributed operations testing
  - Test suite for validation

  ## Usage

  Replace basic torchrun with enhanced configuration:

  ```bash
  torchrun --nnodes=4 --nproc_per_node=8 --node_rank=$NODE_RANK \
    --rdzv_backend=c10d --rdzv_endpoint=$MASTER_ADDR:$MASTER_PORT \
    --rdzv_id=$JOB_ID --rdzv_conf="timeout=1800,read_timeout=120" \
    scripts/diffusion/train.py

  Backward Compatibility

  -  100% backward compatible - no breaking changes
  -  Enhanced error messages guide users to solutions
  -  New features opt-in via environment variables

  Testing

  - Tested with logic validation
  - 2-node test configuration provided
  - Unit tests included

  Fixes #6349