### PR TITLE
fix: remove hardcoded bfloat16 dtype in OddsRatioLoss

### DIFF
--- a/applications/ColossalChat/coati/models/loss.py
+++ b/applications/ColossalChat/coati/models/loss.py
@@ -205,6 +205,7 @@ class OddsRatioLoss(nn.Module):
         chosen_loss_mask: torch.Tensor,
         reject_loss_mask: torch.Tensor,
     ) -> torch.Tensor:
+        input_dtype = chosen_logp.dtype
         chosen_logp = chosen_logp.to(dtype=torch.float32)
         reject_logp = reject_logp.to(dtype=torch.float32)
         chosen_odds = chosen_logp - torch.log(-torch.exp(chosen_logp) + 1.0001)
@@ -213,7 +214,7 @@ class OddsRatioLoss(nn.Module):
         reject_odds_masked = torch.sum(reject_odds * reject_loss_mask.float()) / torch.sum(reject_loss_mask)
         log_odds_ratio = chosen_odds_masked - reject_odds_masked
         ratio = torch.log(torch.nn.functional.sigmoid(log_odds_ratio))
-        return ratio.to(dtype=torch.bfloat16), log_odds_ratio
+        return ratio.to(dtype=input_dtype), log_odds_ratio
 
 
 class KTOLoss(nn.Module):


### PR DESCRIPTION
## Bug
`OddsRatioLoss` returns tensors with hardcoded `bfloat16` dtype regardless of input dtype, causing dtype mismatch errors during mixed-precision training with float32 or float16.

## Fix
Changed to use the input tensor's dtype for consistent dtype propagation.