### PR TITLE
fix: numerically unstable log-odds in ORPO loss

### DIFF
--- a/applications/ColossalChat/coati/models/loss.py
+++ b/applications/ColossalChat/coati/models/loss.py
@@ -207,9 +207,14 @@ class OddsRatioLoss(nn.Module):
     ) -> torch.Tensor:
         chosen_logp = chosen_logp.to(dtype=torch.float32)
         reject_logp = reject_logp.to(dtype=torch.float32)
-        chosen_odds = chosen_logp - torch.log(-torch.exp(chosen_logp) + 1.0001)
+        # Clamp log-probabilities to avoid numerical instability in log-odds computation.
+        # log_odds = log(p) - log(1 - p) = logp - log1p(-exp(logp))
+        eps = 1e-6
+        chosen_logp = torch.clamp(chosen_logp, max=-eps)
+        reject_logp = torch.clamp(reject_logp, max=-eps)
+        chosen_odds = chosen_logp - torch.log1p(-torch.exp(chosen_logp))
         chosen_odds_masked = torch.sum(chosen_odds * chosen_loss_mask.float()) / torch.sum(chosen_loss_mask)
-        reject_odds = reject_logp - torch.log(-torch.exp(reject_logp) + 1.0001)
+        reject_odds = reject_logp - torch.log1p(-torch.exp(reject_logp))
         reject_odds_masked = torch.sum(reject_odds * reject_loss_mask.float()) / torch.sum(reject_loss_mask)
         log_odds_ratio = chosen_odds_masked - reject_odds_masked
         ratio = torch.log(torch.nn.functional.sigmoid(log_odds_ratio))


### PR DESCRIPTION
## Bug

The ORPO loss (`OddsRatioLoss` in `applications/ColossalChat/coati/models/loss.py`) computes log-odds using a numerically fragile pattern:

```python
chosen_odds = chosen_logp - torch.log(-torch.exp(chosen_logp) + 1.0001)
```

This has two problems:

1. **Biased constant**: The magic value `1.0001` shifts the result away from the mathematically correct value, introducing a systematic bias into the loss.
2. **NaN risk**: When `exp(logp) > 1.0001` (which can happen due to floating-point imprecision, especially in mixed-precision training), the argument to `torch.log` becomes negative, producing NaN and poisoning the training run.

The mathematically correct log-odds formula is `log(p) - log(1-p) = logp - log(1 - exp(logp))`.

## Fix

- Clamp `logp` to `(-inf, -eps]` so that `exp(logp)` is strictly less than 1, preventing both division by zero and negative arguments to log.
- Replace `torch.log(-torch.exp(logp) + 1.0001)` with `torch.log1p(-torch.exp(logp))`, which is the numerically correct and unbiased way to compute `log(1 - exp(logp))`.

This eliminates both the NaN risk and the systematic bias from the hardcoded offset.