### PR TITLE
fix infinite recursion in ColoTracer on newer PyTorch versions

### DIFF
--- a/colossalai/fx/tracer/tracer.py
+++ b/colossalai/fx/tracer/tracer.py
@@ -149,6 +149,11 @@ class ColoTracer(Tracer):
 
         return proxy
 
+    def getattr(self, attr, attr_val, parameter_proxy_cache):
+        if getattr(self, "_disable_module_getattr", False):
+            return attr_val
+        return super().getattr(attr, attr_val, parameter_proxy_cache)
+
     def _module_getattr(self, attr, attr_val, parameter_proxy_cache):
         if getattr(self, "_disable_module_getattr", False):
             return attr_val


### PR DESCRIPTION
Newer versions of PyTorch renamed `_module_getattr` to `getattr` in the `Tracer` class, so the `_disable_module_getattr` guard in `ColoTracer._module_getattr` was never reached, causing infinite recursion when computing metadata for `get_attr` nodes. Added a `getattr` override with the same early-return guard to cover both old and new PyTorch versions. Fixes #6413