### PR TITLE
Fix GPT-2 FlashAttention mask preparation without pipeline

### DIFF
--- a/colossalai/shardformer/modeling/gpt2.py
+++ b/colossalai/shardformer/modeling/gpt2.py
@@ -43,7 +43,7 @@ def _get_attention_mask(
     # Received input is already split for non-first pipeline stages,
     # but attn mask isn't
     batch_size = hidden_states.size(0)
-    seq_len = attention_mask.size(-1)
+    seq_len = attention_mask.size(-1) if attention_mask is not None else hidden_states.size(1)
 
     sp_mode = shard_config.sequence_parallelism_mode
     # If a 2D or 3D attention mask is provided for the cross-attention

--- a/colossalai/shardformer/policies/gpt2.py
+++ b/colossalai/shardformer/policies/gpt2.py
@@ -277,7 +277,9 @@ class GPT2Policy(Policy):
                 target_key=GPT2Attention,
             )
 
-        if not self.shard_config.pipeline_stage_manager and self.shard_config.enable_sequence_parallelism:
+        if not self.shard_config.pipeline_stage_manager and (
+            self.shard_config.enable_sequence_parallelism or use_flash_attention
+        ):
             policy[GPT2Model].method_replacement = {
                 "forward": partial(GPT2PipelineForwards.gpt2_model_forward, shard_config=self.shard_config)
             }

--- a/tests/test_shardformer/test_model/test_shard_gpt2.py
+++ b/tests/test_shardformer/test_model/test_shard_gpt2.py
@@ -139,6 +139,14 @@ def check_forward_backward(model_fn, data_gen_fn, output_transform_fn, loss_fn, 
     "test_config",
     [
         {
+            "tp_size": 1,
+            "pp_size": 1,
+            "enable_all_optimization": True,
+            "use_lazy_init": False,
+            "precision": "fp32",
+            "initial_scale": 1,
+        },
+        {
             "sp_size": 2,
             "tp_size": 1,
             "pp_size": 2,


### PR DESCRIPTION
## What changed

- use ColossalAI's GPT-2 model forward whenever FlashAttention is enabled without pipeline parallelism, not only when sequence parallelism is enabled
- let GPT-2 attention-mask preparation handle calls without an explicit mask
- add the reported `tp_size=1`, `pp_size=1`, `enable_all_optimization=True` configuration to the GPT-2 regression matrix

## Why

For a non-pipeline, non-sequence-parallel GPT-2 model, the policy replaced `GPT2Attention.forward` with the ColoAttention implementation but left the Hugging Face `GPT2Model.forward` unchanged. Hugging Face passed its additive attention-mask Tensor directly to the replacement, which attempted `**attention_mask` and raised a TypeError because the value was not a mapping.

The existing ColossalAI GPT-2 model forward already converts masks into the keyword dictionary expected by ColoAttention and preserves causal-mask behavior.

## Impact

GPT-2 works with `HybridParallelPlugin(enable_all_optimization=True)` when TP, PP, and SP sizes are all one.

Fixes #6389.

## Validation

- 2-GPU minimal GPT-2 training regression with the reported plugin configuration and a padded Tensor mask: forward, backward, and optimizer step passed
- `compileall` and `git diff --check`: passed
