### PR TITLE
ci: add names to compatibility matrix steps for readability

### DIFF
--- a/.github/workflows/compatiblity_test_on_pr.yml
+++ b/.github/workflows/compatiblity_test_on_pr.yml
@@ -17,7 +17,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
-      - id: set-matrix
+      - name: Build compatibility container matrix
+        id: set-matrix
         run: |
           IFS=','
           DOCKER_IMAGE=()

--- a/.github/workflows/compatiblity_test_on_schedule.yml
+++ b/.github/workflows/compatiblity_test_on_schedule.yml
@@ -14,7 +14,8 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v3
-      - id: set-matrix
+      - name: Build compatibility container matrix
+        id: set-matrix
         run: |
           IFS=','
           DOCKER_IMAGE=()


### PR DESCRIPTION
## Problem

In the compatibility test workflows, the `set-matrix` step is a long unnamed `run` block, so the Actions UI shows a generic label while building the container matrix.

## Changes

Semantics are unchanged: same `id: set-matrix`, same matrix output wiring, and the same script (including the existing `::set-output` usage).

- Add `name: Build compatibility container matrix` in `compatiblity_test_on_pr.yml`
- Add the same name in `compatiblity_test_on_schedule.yml`

## Test plan
- [ ] Confirm `matrix_preparation.outputs.matrix` still comes from `steps.set-matrix.outputs.matrix`
- [ ] Confirm the matrix-building script is unchanged
