### PR TITLE
[fp8]: Read detected local world size environment variable

### DIFF
--- a/colossalai/quantization/fp8.py
+++ b/colossalai/quantization/fp8.py
@@ -39,7 +39,8 @@ def process_group_is_intranode(pg):
     local_world_size = None
     for var in ["LOCAL_WORLD_SIZE", "OMPI_COMM_WORLD_LOCAL_SIZE", "SLURM_TASKS_PER_NODE"]:
         if var in os.environ:
-            local_world_size = int(os.environ["LOCAL_WORLD_SIZE"])
+            local_world_size = int(os.environ[var])
+            break
     if local_world_size is None:
         local_world_size = torch.cuda.device_count()
 

--- a/tests/test_fp8/test_fp8_utils.py
+++ b/tests/test_fp8/test_fp8_utils.py
@@ -1,0 +1,29 @@
+import pytest
+
+from colossalai.quantization import fp8
+
+
+@pytest.mark.parametrize(
+    "local_world_size_var",
+    ["LOCAL_WORLD_SIZE", "OMPI_COMM_WORLD_LOCAL_SIZE", "SLURM_TASKS_PER_NODE"],
+)
+@pytest.mark.parametrize(
+    "group_ranks, expected",
+    [([0, 1, 2, 3], True), ([0, 1, 4, 5], False)],
+)
+def test_process_group_is_intranode(monkeypatch, local_world_size_var, group_ranks, expected):
+    for var in ["LOCAL_WORLD_SIZE", "OMPI_COMM_WORLD_LOCAL_SIZE", "SLURM_TASKS_PER_NODE"]:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv(local_world_size_var, "4")
+    monkeypatch.setattr(fp8.dist, "get_process_group_ranks", lambda _: group_ranks)
+
+    assert fp8.process_group_is_intranode(object()) is expected
+
+
+def test_process_group_is_intranode_prefers_torchrun_local_world_size(monkeypatch):
+    monkeypatch.setenv("LOCAL_WORLD_SIZE", "4")
+    monkeypatch.setenv("OMPI_COMM_WORLD_LOCAL_SIZE", "2")
+    monkeypatch.setenv("SLURM_TASKS_PER_NODE", "1")
+    monkeypatch.setattr(fp8.dist, "get_process_group_ranks", lambda _: [0, 3])
+
+    assert fp8.process_group_is_intranode(object()) is True


### PR DESCRIPTION
## 📌 Checklist before creating the PR

- [x] I have created an issue for this PR for traceability
- [x] The title follows the standard format: `[doc/gemini/tensor/...]: A concise description`
- [x] I have installed pre-commit: `pip install pre-commit && pre-commit install`

## 🚨 Issue number

Fixed #6437

## 📝 What does this PR do?

`process_group_is_intranode()` previously detected the first available local-world-size environment variable but always read `LOCAL_WORLD_SIZE`. Jobs launched with OpenMPI or Slurm therefore raised `KeyError` before FP8 collectives could select the intranode path.

This change reads the detected variable and stops at the first match, preserving the existing priority order: torchrun, OpenMPI, then Slurm.

Regression tests cover:

- torchrun, OpenMPI, and Slurm environment variables independently;
- intranode and cross-node process groups;
- deterministic priority when several variables are present.

Validation:

- `pytest -q --confcutdir=tests/test_fp8 tests/test_fp8/test_fp8_utils.py` — 7 passed
- `pre-commit run --files colossalai/quantization/fp8.py tests/test_fp8/test_fp8_utils.py` — all hooks passed

The repository-level test fixture invokes GPU accelerator cache hooks during collection, so the full GPU suite is left to CI; the new regression itself is CPU-safe.

## 💥 Checklist before requesting a review

- [x] I have linked my PR to an issue
- [x] My issue clearly describes the problem and includes a minimal reproduction
- [x] I have performed a self-review of my code
- [x] I have added thorough tests
- [ ] I have added docstrings for all the functions/methods I implemented (no new functions or methods)

## ⭐️ Do you enjoy contributing to Colossal-AI?

- [ ] 🌝 Yes, I do.
- [ ] 🌚 No, I don't.
